### PR TITLE
ci: unpin mermaid-sync workflows back to .github@main

### DIFF
--- a/.github/workflows/mermaid-sync.yml
+++ b/.github/workflows/mermaid-sync.yml
@@ -12,11 +12,7 @@ on:
 jobs:
   check:
     if: github.event_name == 'pull_request'
-    # Pin to pre_docs until Bardie-radio/.github#3 lands on main (root-path mermaid-sync).
-    # After merge: switch both lines back to @main / ci_ref main (or drop ci_ref).
-    uses: Bardie-radio/.github/.github/workflows/reusable-mermaid-check.yml@pre_docs
-    with:
-      ci_ref: pre_docs
+    uses: Bardie-radio/.github/.github/workflows/reusable-mermaid-check.yml@main
     permissions:
       contents: read
       pull-requests: write
@@ -33,9 +29,7 @@ jobs:
         github.event.review.body != '' &&
         contains(github.event.review.body, '/mermaid-sync')
       )
-    uses: Bardie-radio/.github/.github/workflows/reusable-mermaid-resolve.yml@pre_docs
-    with:
-      ci_ref: pre_docs
+    uses: Bardie-radio/.github/.github/workflows/reusable-mermaid-resolve.yml@main
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Summary
- Revert the temporary mermaid-sync pin from `@pre_docs` back to `@main` now that [Bardie-radio/.github#3](https://github.com/Bardie-radio/.github/pull/3) has merged.

## Test plan
- [ ] Confirm reusable workflows resolve on `main`
- [ ] Optional: open a docs PR touching `docs/**` and verify Mermaid sync check passes
