### PR TITLE
docs: treat Phase 7 as Plume umbrella and lock /control vs /player paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Kithara sits at the center of Bardie. **Client modules**, **source modules**, an
 
 ```text
 ├── Client modules       → User-facing control and discovery surfaces
-│   ├── Plume            → Web UI (MVP); / and /player/{slug}
+│   ├── Plume            → Web UI (MVP); `/`, `/control/{slug}`, `/player/{slug}`
 │   ├── Beak             → Discord voice + stream control (future)
 │   └── Cauda            → Telegram remote Struna control (future)
 ├── Source modules       → Audio providers (gRPC + FIFO)
@@ -57,8 +57,9 @@ More client modules may follow — Bardie does not assume a single UI; it assume
 |------|---------|
 | `/api` | Kithara REST API |
 | `/stream/{slug}` | Live ICY-over-HTTP audio (Kithara) |
-| `/player/{slug}` | Stream control surface (**Plume** — not served by Kithara) |
-| `/` | Plume main UI |
+| `/control/{slug}` | Remote control desk (**Plume** — not served by Kithara) |
+| `/player/{slug}` | Listen / player surface (**Plume** — not served by Kithara) |
+| `/` | Plume home |
 
 Full routing detail: [uri-routing](docs/architecture/interfaces/uri-routing.md).
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -74,6 +74,7 @@ Deep-dive architecture for **Kithara** — the Bardie core backend. For ecosyste
 - [v0.1-milestones](mvp/v0.1-milestones.md)
 - [implementation-plan](mvp/implementation-plan.md)
 - [security-audit](mvp/security-audit.md)
+- [known-issues](mvp/known-issues.md)
 
 ### Spike
 - [prototype-neck-ffmpeg](spike/prototype-neck-ffmpeg.md)

--- a/docs/architecture/adrs/009-struna-access-and-routing.md
+++ b/docs/architecture/adrs/009-struna-access-and-routing.md
@@ -13,9 +13,12 @@ Streams need human-readable URLs, separate listen vs control permissions, and le
 | Path | Service |
 |------|---------|
 | `/` | Plume (auth required) |
+| `/control/{slug}` | Plume remote control desk |
+| `/player/{slug}` | Plume listen / player surface |
 | `/api/*` | Kithara REST |
 | `/stream/{slug}` | Kithara Stream Server |
-| `/player/{slug}` | Plume control page |
+
+`/player` used to mean the control UI; Plume MVP flips that — control is `/control/{slug}`, listen UI is `/player/{slug}`. No `/listen` path.
 
 **Slug:** user-chosen; unique among **alive** Strunas; freed on **DELETE** (or silent cleanup).
 

--- a/docs/architecture/domains/clients.md
+++ b/docs/architecture/domains/clients.md
@@ -18,7 +18,7 @@ A **client module** is a separate deployable that presents Bardie on some channe
 
 Out of scope for “client module”: legacy players (VLC, direct browser playback, etc) that only hit `GET /stream/{slug}`, no control over system or authorization in most cases
 
-Kithara does **not** serve `/` or `/player/`* — those belong to a UI client (typically Plume) at the edge. See [uri-routing](../interfaces/uri-routing.md).
+Kithara does **not** serve `/`, `/control/*`, or `/player/*` — those belong to a UI client (typically Plume) at the edge. See [uri-routing](../interfaces/uri-routing.md).
 
 ## Auth modes (contract)
 

--- a/docs/architecture/domains/playback-control.md
+++ b/docs/architecture/domains/playback-control.md
@@ -30,13 +30,13 @@ Endpoint sketch and payloads: [rest-api](../interfaces/rest-api.md).
 ## Now playing
 
 - ICY `StreamTitle` updated on Stream Server
-- REST `GET /api/streams/{id}/now-playing` for clients
-- Optional future: SSE/WebSocket events
+- REST `GET /api/streams/{id}/now-playing` for clients (MVP UIs **poll**)
+- Optional future: **Browser → Kithara** SSE/WebSocket for now-playing / queue push (auth ticket compatible with Plume BFF — no Plume fan-out proxy). Tracking: [kithara#28](https://github.com/Bardie-radio/kithara/issues/28); not an MVP Plume phase.
 
 ## Permissions
 
 Controlled by Struna **control access** mode — see [struna-access.md](struna-access.md). Protected control uses a short **guest code** exchanged for an **ephemeral guest user** + JWT (not the code on every request).
 
-**Related:** [ADR 001](../adrs/001-broadcast-sync-model.md) · [struna-access.md](struna-access.md) · [streams.md](streams.md) · [source-instances.md](source-instances.md)
+**Related:** [ADR 001](../adrs/001-broadcast-sync-model.md) · [struna-access.md](struna-access.md) · [streams.md](streams.md) · [source-instances.md](source-instances.md) · [uri-routing](../interfaces/uri-routing.md) · [Browser→Kithara event channel (#28)](https://github.com/Bardie-radio/kithara/issues/28)
 
 **Read next:** [clients.md](clients.md)

--- a/docs/architecture/domains/streams.md
+++ b/docs/architecture/domains/streams.md
@@ -14,10 +14,10 @@ A **Struna** (stream) is a named broadcast channel managed by **Neck** inside Ki
 | Field | Purpose |
 |-------|---------|
 | `Id` | Internal GUID — API paths, DB, traces |
-| `Slug` | User-chosen URL name — `/stream/{slug}`, `/player/{slug}` |
+| `Slug` | User-chosen URL name — `/stream/{slug}`, `/control/{slug}`, `/player/{slug}` |
 | `Title` | Display name |
 
-**Slug rules:** lowercase alphanumeric + hyphens; unique among **alive** Strunas; HTTP 409 on conflict. Listen URLs live under `/stream/{slug}` — that path prefix already isolates them from `/api/…` and `/player/…`, so we do **not** maintain a reserved-name denylist for route collisions (a Struna may be named `api` or `player`).
+**Slug rules:** lowercase alphanumeric + hyphens; unique among **alive** Strunas; HTTP 409 on conflict. Listen URLs live under `/stream/{slug}` — that path prefix already isolates them from `/api/…`, `/control/…`, and `/player/…`, so we do **not** maintain a reserved-name denylist for route collisions (a Struna may be named `api`, `control`, or `player`).
 
 **Alive from create (two layers):**
 

--- a/docs/architecture/domains/struna-access.md
+++ b/docs/architecture/domains/struna-access.md
@@ -7,13 +7,13 @@ flowchart TB
     PR[protected listen token]
     PV[private full auth]
   end
-  subgraph control [Control /player/slug]
+  subgraph control [Control /control/slug]
     CP[private full auth]
     CG[protected guest exchange]
   end
 ```
 
-Playback and control access are **fully independent** per Struna.
+Playback and control access are **fully independent** per Struna. Plume’s remote desk is `/control/{slug}`; the listen / player UI is `/player/{slug}` — see [uri-routing](../interfaces/uri-routing.md).
 
 ## Playback (listening)
 

--- a/docs/architecture/glossary.md
+++ b/docs/architecture/glossary.md
@@ -14,7 +14,7 @@ Dual naming: **codename** (musical instruments theme) + **plain English**. When 
 | **ICY** / **ICY-over-HTTP** | Shoutcast-style metadata stream | Continuous HTTP audio with in-band `StreamTitle` / `icy-metaint` metadata |
 | **Tune** | Library item | Shared library unit: queue + history + optional blob cache; module + external id; not stream-owned |
 | **QueueEntry** | Queue item | Struna queue slot pointing at a **Tune id** |
-| **Plume** | Web UI client module | Optional **user-aware** client: `/`, `/player/{slug}` |
+| **Plume** | Web UI client module | Optional **user-aware** client: `/`, `/control/{slug}` (remote desk), `/player/{slug}` (listen surface) |
 | **Beak** | Discord bot client | Future **static** client: play Strunas in Discord voice; guild-scoped managed users |
 | **Cauda** | Telegram bot client | Future **user-aware** client: remote Struna control from Telegram chats |
 | **Client module** | User-facing integration | Deployable surface (Plume, Beak, Cauda, …) that calls Kithara REST |

--- a/docs/architecture/interfaces/rest-api.md
+++ b/docs/architecture/interfaces/rest-api.md
@@ -158,6 +158,6 @@ Quickplay / quickqueue still pick a source via configured **priority** (and late
 - `429` — guest exchange rate-limited (Phase 6 / GUEST-XCHG-001)
 - `502` — source/auth **module dial failed** (gRPC/capability/search/`StartTrack`/`PauseTrack`/… upstream error). Body includes an `error` string; do not treat as a client validation failure
 
-**Related:** [auth.md](auth.md) · [struna-access](../domains/struna-access.md) · [playback-control](../domains/playback-control.md) · [source-modules](../domains/source-modules.md) · [streams](../domains/streams.md)
+**Related:** [auth.md](auth.md) · [struna-access](../domains/struna-access.md) · [playback-control](../domains/playback-control.md) · [source-modules](../domains/source-modules.md) · [streams](../domains/streams.md) · post-MVP [Browser→Kithara event channel (#28)](https://github.com/Bardie-radio/kithara/issues/28)
 
 **Read next:** [grpc-source-module.md](grpc-source-module.md)

--- a/docs/architecture/interfaces/uri-routing.md
+++ b/docs/architecture/interfaces/uri-routing.md
@@ -5,19 +5,20 @@ Public path map for one Bardie hostname. Edge product and Compose layout live in
 ```mermaid
 flowchart TB
   Proxy[Reverse proxy]
-  Proxy -->|/ and /player/*| Plume
+  Proxy -->|/ and /control/* and /player/*| Plume
   Proxy -->|/api/*| Kithara
   Proxy -->|/stream/*| Kithara
 ```
 
-**Stream Server is inside Kithara** — `/stream/*` is not a separate container. Plume is optional; without it, `/` and `/player/*` simply have no UI target at the edge.
+**Stream Server is inside Kithara** — `/stream/*` is not a separate container. Plume is optional; without it, `/`, `/control/*`, and `/player/*` simply have no UI target at the edge.
 
 ## Route table
 
 | Path | Target | Auth |
 |------|--------|------|
 | `/` | Plume (optional) | Auth required when Plume is used |
-| `/player/{slug}` | Plume (optional) | Per Struna control mode |
+| `/control/{slug}` | Plume (optional) | Per Struna **control** mode — remote control desk |
+| `/player/{slug}` | Plume (optional) | Per Struna **playback** mode — listen / player surface |
 | `/api/*` | Kithara REST (incl. auth + `…/guest/exchange` + global search) | Login JWT; ephemeral guest JWT; join secret only for static-module admin |
 | `/stream/{slug}` | Kithara Stream Server | Per Struna playback mode |
 
@@ -25,10 +26,13 @@ gRPC (`:5000`) is **not** on this map — modules reach Kithara on the internal 
 
 Beak, Cauda, Magpie, Bes, … do **not** get public path prefixes; they talk to Kithara over REST or gRPC as modules.
 
+Older docs called `/player/{slug}` the control UI. Plume MVP **reassigns** `/player` to the listen surface and introduces `/control` for the remote-control desk. There is **no** `/listen` path.
+
 ## Slug in URLs
 
-- Listener: `https://bardie.example/stream/friday-jazz`
-- Control UI: `https://bardie.example/player/friday-jazz`
+- Listener (ICY): `https://bardie.example/stream/friday-jazz`
+- Control desk: `https://bardie.example/control/friday-jazz`
+- Listen / player UI: `https://bardie.example/player/friday-jazz`
 - API uses internal GUID: `/api/streams/{id}/skip`
 
 ## What Kithara owns on the wire
@@ -44,7 +48,7 @@ Long-lived `/stream/{slug}` needs generous proxy read timeouts — see [operatio
 
 | Change | Follow up in |
 |--------|--------------|
-| Path map `/`, `/player/*`, `/api/*`, `/stream/*` | **plume** (UI routes); **org** edge/Compose ([05-deployment](https://github.com/Bardie-radio/.github/blob/main/profile/docs/architecture/05-deployment.md)) |
+| Path map `/`, `/control/*`, `/player/*`, `/api/*`, `/stream/*` | **plume** (UI routes); **org** edge/Compose ([05-deployment](https://github.com/Bardie-radio/.github/blob/main/profile/docs/architecture/05-deployment.md)) |
 | Published ports / service DNS | Org reference Compose — not duplicated here |
 
 **Related:** [operations/deployment.md](../operations/deployment.md) · [auth.md](auth.md) · [ADR 009](../adrs/009-struna-access-and-routing.md) · [org deployment](https://github.com/Bardie-radio/.github/blob/main/profile/docs/architecture/05-deployment.md)

--- a/docs/architecture/mvp/README.md
+++ b/docs/architecture/mvp/README.md
@@ -6,4 +6,4 @@
 - [v0.1-milestones.md](v0.1-milestones.md) — short delivery ladder
 - [implementation-plan.md](implementation-plan.md) — ordered work packages, modularity rules, finding → phase map
 - [security-audit.md](security-audit.md) — mesh + SURFACE-TOPIC findings; Phases 4–6 remediations closed (soft residuals → Phase 8)
-- [known-issues.md](known-issues.md) — non-security footguns (`NECK-*`); GitHub links
+- [known-issues.md](known-issues.md) — non-security footguns (`NECK-*`); Plume-local IDs live in Plume

--- a/docs/architecture/mvp/implementation-plan.md
+++ b/docs/architecture/mvp/implementation-plan.md
@@ -91,7 +91,7 @@ Phases are **dependency-ordered** for *shipping* outcomes. Phases 4–6 ran in p
 | **4** | Neck + encode | Alive Struna, silence feeder, FFmpeg supervisor + **Channel peer pin (MESH-CHN-001)** | Complete |
 | **5** | Stream Server | `GET /stream/{slug}` ICY + listen-token gate | Complete |
 | **6** | Control REST + auth hardening | Remaining control depth + **security P0/P1** + harness routing (AUTH-ORCH-001) | Complete |
-| **7** | Plume MVP | Discovery login + control UI (optional client) | **Next** |
+| **7** | Plume MVP | Umbrella: reference UI exists (Plume Phases 1–6) | **Next** |
 | **8** | Compose + verify | Reference stack, join secrets, OTLP E2E, **QA/OPS/DOC debt** | After 7 (or parallel) |
 
 
@@ -422,30 +422,32 @@ libs/
 
 **Why:** Reference user-aware UI; stack must still work without it.
 
-### Work (Plume)
+Kithara Phase 7 is the **stack umbrella** — “Plume exists and meets exit criteria.” Delivery order lives in Plume’s own phases:
 
-1. Edge routes `/`, `/player/{slug}`.
-2. Discovery-driven Bes login; store Bearer + refresh.
-3. Wire control verbs; guest exchange UX for protected control.
-4. Browser player **off by default**; optional listen to `/stream/{slug}`.
-5. OTel `bardie.plume`.
+- [Plume implementation plan](https://github.com/Bardie-radio/plume/blob/main/docs/architecture/mvp/implementation-plan.md) (Plume Phases 1–6)
+- [Plume UI stack](https://github.com/Bardie-radio/plume/blob/main/docs/architecture/03-ui-stack.md) (`/control/{slug}` desk vs `/player/{slug}` listen surface)
 
+Do **not** renumber Plume work as “Kithara 7.1 / 7.2”. Satisfies this phase when Plume Phases 1–6 exit.
 
+### Work (Plume — summary)
+
+1. Edge routes `/`, `/control/{slug}`, `/player/{slug}`.
+2. BFF session + discovery-driven Bes login (no JWT in browser).
+3. Control desk (`/control/{slug}`): queue, search, transport; poll now-playing.
+4. Listen surface (`/player/{slug}`): prominent now-playing; browser audio **off by default**; optional `/stream/{slug}`.
+5. Guest exchange UX for protected control; Register + OTel `bardie.plume`.
 
 ### Exit criteria
 
 - Human can create a Struna, search Magpie, play, and hear it in VLC via `/stream/{slug}`.
 - Removing Plume from Compose leaves API + stream + modules working.
 
-
-
 ### Cross-repo
-
 
 | Repo      | Follow-up                                                                                             |
 | --------- | ----------------------------------------------------------------------------------------------------- |
-| **plume** | [mvp/v0.1-scope](https://github.com/Bardie-radio/plume/blob/main/docs/architecture/mvp/v0.1-scope.md) |
-| **org**   | Edge path map already documented — keep aligned                                                       |
+| **plume** | [implementation-plan](https://github.com/Bardie-radio/plume/blob/main/docs/architecture/mvp/implementation-plan.md) · [03-ui-stack](https://github.com/Bardie-radio/plume/blob/main/docs/architecture/03-ui-stack.md) · [mvp/v0.1-scope](https://github.com/Bardie-radio/plume/blob/main/docs/architecture/mvp/v0.1-scope.md) |
+| **org**   | Edge path map `/control/*` + `/player/*` — keep aligned                                                       |
 
 
 ---

--- a/docs/architecture/mvp/known-issues.md
+++ b/docs/architecture/mvp/known-issues.md
@@ -2,6 +2,8 @@
 
 Living index of **non-security** product / design footguns discovered after Phases 4–6. Security findings stay in [security-audit.md](security-audit.md). Soft residuals already listed there (e.g. `NECK-JOB-001`, `AUTH-ROT-002`) are not duplicated here unless they need a design note.
 
+**Plume-local** scaffold / BFF / UI footguns (`PLUME-*`) live in [Plume known-issues](https://github.com/Bardie-radio/plume/blob/main/docs/architecture/mvp/known-issues.md) — do not duplicate them here.
+
 **Owner default:** Phase 8 polish unless noted.
 
 IDs use `SURFACE-TOPIC-NNN` (see [security-audit ID scheme](security-audit.md#id-scheme)). Former `KI-*` aliases: `KI-01` → `NECK-PCM-001`, `KI-02` → `NECK-SWP-001`.

--- a/docs/architecture/mvp/v0.1-milestones.md
+++ b/docs/architecture/mvp/v0.1-milestones.md
@@ -25,9 +25,9 @@ flowchart TB
 4. **Source module protocol** — gRPC + FIFO PCM proof with Magpie (`StartTrack` / `StopTrack`); OTel `bardie.source.magpie` — **done**
 5. **Neck refactor** — encode-alive create, session FIFO, silence feeder, hosted FFmpeg supervisor (custom spans) — **done**
 6. **Stream Server** — ICY-over-HTTP `/stream/{slug}` — **done**
-7. **Plume** — `/`, `/player/{slug}`, discovery-driven login (optional client); OTel `bardie.plume` — **current**
+7. **Plume** — `/`, `/control/{slug}`, `/player/{slug}` — Kithara Phase 7 umbrella; delivery is [Plume Phases 1–6](https://github.com/Bardie-radio/plume/blob/main/docs/architecture/mvp/implementation-plan.md); OTel `bardie.plume` — **current**
 8. **Compose bundle** — edge + 4 apps; join secrets; **confirm** OTLP → external collector (instrumentation already present)
 
-**Related:** [v0.1-scope.md](v0.1-scope.md) · [implementation-plan.md](implementation-plan.md)
+**Related:** [v0.1-scope.md](v0.1-scope.md) · [implementation-plan.md](implementation-plan.md) · [Plume implementation plan](https://github.com/Bardie-radio/plume/blob/main/docs/architecture/mvp/implementation-plan.md)
 
 **Read next:** [implementation-plan.md](implementation-plan.md) for work packages · [../spike/prototype-neck-ffmpeg.md](../spike/prototype-neck-ffmpeg.md)

--- a/docs/architecture/mvp/v0.1-scope.md
+++ b/docs/architecture/mvp/v0.1-scope.md
@@ -4,7 +4,7 @@
 flowchart TB
   subgraph in_scope [In scope]
     K[Kithara API + Stream]
-    P[Plume / and /player]
+    P[Plume / control / player]
     Magpie[Magpie ytdl]
     Bes[Bes password auth]
     OTel[Full OTel]
@@ -19,7 +19,7 @@ flowchart TB
 - User-chosen slugs; unique among **alive** Strunas; freed on delete
 - Struna access: independent playback (public/protected/private) and control (private/protected)
 - Protected listen token via query param (MVP); guest code → **ephemeral guest user** + Kithara JWT for protected control; secrets owned by Kithara
-- Plume: `/`, `/player/{slug}`; browser player off by default (optional client — stack works without it)
+- Plume: `/`, `/control/{slug}` (remote desk), `/player/{slug}` (listen surface); browser audio off by default (optional client — stack works without it)
 - **Bes** login+password adapter (separate container; module-issued JWT sessions)
 - **Magpie** YouTube / ytdl source module (gRPC + FIFO PCM)
 - OTel on **all** Bardie app components
@@ -33,7 +33,8 @@ flowchart TB
 - **Catbird** file upload module 
 - **Starling** local stream
 - Icecast / HLS as primary output (keep adapters possible later; not MVP)
-- `/player` PWA
+- Plume PWA
+- Browser → Kithara SSE/WebSocket event channel (post-MVP; see [playback-control](../domains/playback-control.md))
 - One-time listen tokens for private streams on legacy players
 - HTTP Basic Auth for protected streams (v0.2 eval)
 - Multi-instance Kithara horizontal scaling

--- a/docs/architecture/operations/deployment.md
+++ b/docs/architecture/operations/deployment.md
@@ -57,7 +57,7 @@ Drop a module on the Compose network with its **join secret** and it registers. 
 | `/api/*` | REST API + auth |
 | `/stream/{slug}` | Stream Server |
 
-`/`, `/player/*` are **not** served here — Plume (or another client) at the edge.
+`/`, `/control/*`, `/player/*` are **not** served here — Plume (or another client) at the edge.
 
 ## Health & lifecycle
 


### PR DESCRIPTION
## Summary
- Treat Kithara Phase 7 as a **Plume umbrella** (delivery = Plume Phases 1–6), not a duplicated work list
- Lock edge paths `/control/{slug}` vs `/player/{slug}` across domains, URI routing, and MVP pages
- Point known-issues at Plume for `PLUME-*` IDs

Companions: [plume#…](https://github.com/Bardie-radio/plume/pulls), [org docs/client-modules-catalog](https://github.com/Bardie-radio/.github/pull/new/docs/client-modules-catalog).
