### PR TITLE
fix(auth): refresh JWKS snapshot on auth module Register

### DIFF
--- a/src/Kithara/Features/Modules/ModuleRegistryOperations.cs
+++ b/src/Kithara/Features/Modules/ModuleRegistryOperations.cs
@@ -4,6 +4,7 @@ using Bardie.Module.Channel.Certificates;
 using Bardie.Modules.V1;
 using Bardie.Harness.Source.Catalog;
 using Grpc.Core;
+using Kithara.Features.Auth;
 using Microsoft.Extensions.Options;
 
 namespace Kithara.Features.Modules;
@@ -21,6 +22,7 @@ public sealed class ModuleRegistryOperations
     private readonly IModuleCertificateIssuer _certificateIssuer;
     private readonly ModuleRegistryOptions _registryOptions;
     private readonly ModuleChannelOptions _channelOptions;
+    private readonly AuthModuleJwksKeyProvider _jwksKeys;
     private readonly ILogger<ModuleRegistryOperations> _logger;
 
     public ModuleRegistryOperations(
@@ -31,6 +33,7 @@ public sealed class ModuleRegistryOperations
         IModuleCertificateIssuer certificateIssuer,
         IOptions<ModuleRegistryOptions> registryOptions,
         IOptions<ModuleChannelOptions> channelOptions,
+        AuthModuleJwksKeyProvider jwksKeys,
         ILogger<ModuleRegistryOperations> logger)
     {
         _registry = registry;
@@ -40,6 +43,7 @@ public sealed class ModuleRegistryOperations
         _certificateIssuer = certificateIssuer;
         _registryOptions = registryOptions.Value;
         _channelOptions = channelOptions.Value;
+        _jwksKeys = jwksKeys;
         _logger = logger;
     }
 
@@ -241,6 +245,9 @@ public sealed class ModuleRegistryOperations
                     LastHeartbeatAt = now,
                     ExpiresAt = expiresAt,
                 });
+                // AUTH-JWKS-001: do not wait up to the hosted-service interval — Bes tokens
+                // validate only after this snapshot includes the module JWKS.
+                _ = RefreshJwksAfterAuthRegisterAsync(slug);
                 break;
 
             case WellKnownModuleKinds.Source:
@@ -274,6 +281,19 @@ public sealed class ModuleRegistryOperations
                     slug,
                     kind);
                 break;
+        }
+    }
+
+    private async Task RefreshJwksAfterAuthRegisterAsync(string slug)
+    {
+        try
+        {
+            await _jwksKeys.RefreshSnapshotAsync(CancellationToken.None).ConfigureAwait(false);
+            _logger.LogInformation("JWKS snapshot refreshed after auth module {Slug} register", slug);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "JWKS snapshot refresh failed after auth module {Slug} register", slug);
         }
     }
 }

--- a/src/Kithara/Program.cs
+++ b/src/Kithara/Program.cs
@@ -35,8 +35,8 @@ builder.Services.AddKitharaBlobStorage(builder.Configuration);
 builder.Services.AddKitharaLibrary();
 builder.Services.AddKitharaNeck(builder.Configuration);
 builder.Services.AddKitharaSearch(builder.Configuration);
-builder.Services.AddModuleRegistry(builder.Configuration);
 builder.Services.AddKitharaAuthAuthentication(builder.Configuration);
+builder.Services.AddModuleRegistry(builder.Configuration);
 builder.Services.AddHostedService<SeedAdminBootstrapHostedService>();
 
 // GUEST-XCHG-001: guest-code exchange is unauthenticated — bound by IP + Struna id.

--- a/tests/Kithara.Tests/ModuleRegistryOperationsTests.cs
+++ b/tests/Kithara.Tests/ModuleRegistryOperationsTests.cs
@@ -209,6 +209,9 @@ public class ModuleRegistryOperationsTests
         });
         services.AddAuthModuleHarness();
         services.AddSourceModuleHarness();
+        services.AddMemoryCache();
+        services.AddHttpClient(nameof(Kithara.Features.Auth.AuthModuleJwksKeyProvider));
+        services.AddSingleton<Kithara.Features.Auth.AuthModuleJwksKeyProvider>();
         services.AddSingleton<InMemoryModuleRegistry>();
         services.Configure<ModuleRegistryOptions>(o =>
         {


### PR DESCRIPTION
## Summary
- Refresh the JWKS snapshot when an auth module registers, so newly registered adapters are usable for JWT verify without a restart.

Small-fix batch branch (`chore/small-fixes`) for low-ceremony patches.
