### PR TITLE
feat: Plume companion access + stream fixes; lock client admin on mTLS

### DIFF
--- a/docs/architecture/adrs/009-struna-access-and-routing.md
+++ b/docs/architecture/adrs/009-struna-access-and-routing.md
@@ -1,6 +1,6 @@
 # ADR 009: Struna Access and Routing
 
-**Status:** Accepted (amended: protected control = guest-code exchange → ephemeral guest user + Kithara-minted JWTs)
+**Status:** Accepted (amended: protected control = guest-code exchange → ephemeral guest user + Kithara-minted JWTs; `hidden` playback = public stream gate, list-omitted)
 
 ## Context
 
@@ -22,7 +22,7 @@ Streams need human-readable URLs, separate listen vs control permissions, and le
 
 **Slug:** user-chosen; unique among **alive** Strunas; freed on **DELETE** (or silent cleanup).
 
-**Playback access** (independent): `public` | `protected` (listen token) | `private` (full auth).
+**Playback access** (independent): `public` | `hidden` (same `/stream` gate as public; omitted from listen lists except owner/control/guest) | `protected` (listen token) | `private` (full auth).
 
 **Control access** (independent): `private` (auth) | `protected` (guest code → **ephemeral guest user** + Kithara-minted JWTs). **No public control.**
 

--- a/docs/architecture/domains/auth-adapters.md
+++ b/docs/architecture/domains/auth-adapters.md
@@ -91,7 +91,7 @@ Users may **explicitly** link/merge bindings from different providers (prove bot
 
 ## Join secrets vs user JWTs
 
-**Join secrets** authenticate modules (register / heartbeats / static admin). They are not user session credentials. **Static** client modules (e.g. Beak) use their join secret only to administer **module-managed users**; day-to-day API calls use **per-user credentials** — see [clients](clients.md).
+**Join secrets** bootstrap module `Register` (Heartbeat is mTLS). They are not user session credentials and must not be used as standing `/api` admin keys. **Static** client modules (e.g. Beak) will administer **module-managed users** over planned **mTLS client→host** RPCs; day-to-day API calls use **per-user credentials** — see [clients](clients.md).
 
 **Related:** [interfaces/auth.md](../interfaces/auth.md) · [interfaces/grpc-auth-adapter.md](../interfaces/grpc-auth-adapter.md) · [ADR 007](../adrs/007-auth-adapter-modules.md)
 

--- a/docs/architecture/domains/clients.md
+++ b/docs/architecture/domains/clients.md
@@ -28,10 +28,20 @@ When a client module registers, it declares how it authenticates to `/api`:
 | Mode           | Meaning                                                                      | Credential on `/api`                                                         |
 | -------------- | ---------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
 | **user-aware** | End users log in; module acts with their identity                            | Bearer **user JWT** from an auth module (via Kithara discovery/authenticate) |
-| **static**     | No human Bardie login through this UI; module owns **many** persistent users | **Join secret** (admin only) + **per-user credentials** (day-to-day)         |
+| **static**     | No human Bardie login through this UI; module owns **many** persistent users | **Per-user credentials** for day-to-day `/api` (no join secret on HTTP)      |
 
 
 Module-level **capability rights** (what the static app may do at all) are declared at registration. Per-user / Struna ACLs still live in Kithara.
+
+### gRPC surface by client mode
+
+| Client | gRPC today | Future (static only) |
+|--------|------------|----------------------|
+| **All** (Plume, Beak, …) | `Register` + `Heartbeat` (join secret = **Register bootstrap only**; Heartbeat = mTLS) | — |
+| **User-aware** | No admin/work RPCs — REST + end-user JWT via BFF | — |
+| **Static** | Same as all | **Client→host managed-user admin** RPCs over mTLS (create/list/revoke + credential mint/reset + ceiling attach) |
+
+There is no client work proto yet and Kithara does not dial a client’s advertise address. Do **not** put managed-user admin on `/api` with the join secret — that would be BFF-reachable and reintroduces shared-secret impersonation. Track as Kithara Feature: *Static client managed-user admin over mTLS gRPC (not join-secret REST)*.
 
 ### Static modules and module-managed users
 
@@ -45,16 +55,16 @@ Do **not**:
 | Many users all acting under the **same** join secret      | Shared-secret impersonation          |
 
 
-**Chosen shape:** join secret for **module admin** (create/list/revoke managed users); each **tenancy boundary** gets a durable `User` with **distinct** credentials for day-to-day `/api`. Kithara records `managed_by_module` + external tenancy ref. At Register the static module advertises a **permission ceiling** (typical: create Strunas + manage ones it created). Creating a managed user may set a narrower entity scope or adjust it at runtime — never above the ceiling; if unset, Kithara defaults to the advertised set. Concrete tenancy keys (e.g. Discord guild) are module-specific — see [org catalog](https://github.com/Bardie-radio/.github/blob/main/profile/docs/architecture/06-client-modules.md) and each module’s docs.
+**Chosen shape:** each **tenancy boundary** gets a durable `User` with **distinct** credentials for day-to-day `/api`. Module-root admin (create/list/revoke managed users, mint/reset creds) is **planned** as **mTLS client→host** RPCs after Register — not join-secret REST. Kithara records `managed_by_module` + external tenancy ref. At Register the static module advertises a **permission ceiling** (typical: create Strunas + manage ones it created). Creating a managed user may set a narrower entity scope or adjust it at runtime — never above the ceiling; if unset, Kithara defaults to the advertised set. Concrete tenancy keys (e.g. Discord guild) are module-specific — see [org catalog](https://github.com/Bardie-radio/.github/blob/main/profile/docs/architecture/06-client-modules.md) and each module’s docs.
 
 ## Attachment to core
 
 1. **Register** — gRPC Module Registry (same as source/auth): join secret + `kind=CLIENT` + auth mode (`user-aware` | `static`) + static module rights when static — [grpc-module-registry](../interfaces/grpc-module-registry.md)
-2. **Auth** — user JWT; or join secret for managed-user admin + per-user credentials for API work; or ephemeral guest JWT after guest exchange
+2. **Auth** — user JWT; or per-managed-user credentials for API work; or ephemeral guest JWT after guest exchange. Static **module admin** → future mTLS admin RPCs (not `/api` + join secret)
 3. **Control** — REST playback/queue/search as in [rest-api](../interfaces/rest-api.md)
 4. **Listen** — optional; `/stream/{slug}` (or embed). Not required to be a client module
 
-Day-to-day control is **REST only** (no source/auth work gRPC from the client process). Join is **always** Registry RPC. Compose / join-secret wiring: [org deployment](https://github.com/Bardie-radio/.github/blob/main/profile/docs/architecture/05-deployment.md) · [operations/deployment](../operations/deployment.md).
+Day-to-day Struna control is **REST only**. Mesh join is **always** Registry RPC. Compose / join-secret wiring: [org deployment](https://github.com/Bardie-radio/.github/blob/main/profile/docs/architecture/05-deployment.md) · [operations/deployment](../operations/deployment.md).
 
 
 ## OTel

--- a/docs/architecture/domains/clients.md
+++ b/docs/architecture/domains/clients.md
@@ -41,7 +41,7 @@ Module-level **capability rights** (what the static app may do at all) are decla
 | **User-aware** | No admin/work RPCs — REST + end-user JWT via BFF | — |
 | **Static** | Same as all | **Client→host managed-user admin** RPCs over mTLS (create/list/revoke + credential mint/reset + ceiling attach) |
 
-There is no client work proto yet and Kithara does not dial a client’s advertise address. Do **not** put managed-user admin on `/api` with the join secret — that would be BFF-reachable and reintroduces shared-secret impersonation. Track as Kithara Feature: *Static client managed-user admin over mTLS gRPC (not join-secret REST)*.
+There is no client work proto yet and Kithara does not dial a client’s advertise address. Do **not** put managed-user admin on `/api` with the join secret — that would be BFF-reachable and reintroduces shared-secret impersonation. Track implementation: [#31](https://github.com/Bardie-radio/kithara/issues/31).
 
 ### Static modules and module-managed users
 

--- a/docs/architecture/domains/streams.md
+++ b/docs/architecture/domains/streams.md
@@ -41,7 +41,7 @@ Neck lives **inside Kithara** — not a separate container. FFmpeg process owner
 
 ## Target schema fields
 
-- `PlaybackAccess`: public | protected | private
+- `PlaybackAccess`: public | hidden | protected | private
 - `ControlAccess`: private | protected
 - `OwnerUserId` + grant list for private control ([auth ACL](../interfaces/auth.md))
 - `ListenToken`, `GuestCode` (nullable; owned by Kithara) — guest code is exchange-only; each exchange creates an ephemeral guest user + JWT

--- a/docs/architecture/domains/struna-access.md
+++ b/docs/architecture/domains/struna-access.md
@@ -117,7 +117,7 @@ Party DJ is still not a durable account — but it **is** a real row in Kithara�
 
 ## Bots / static clients
 
-**Managed users** (day-to-day control) plus module **join secret** for admin only — see [clients](clients.md). For listen-only bots, a **protected** Struna with a known listen token also works.
+**Managed users** (day-to-day control) plus planned **mTLS module admin** for create/revoke — see [clients](clients.md). For listen-only bots, a **protected** Struna with a known listen token also works.
 
 **Related:** [interfaces/http-stream-output.md](../interfaces/http-stream-output.md) · [interfaces/auth.md](../interfaces/auth.md) · [ADR 009](../adrs/009-struna-access-and-routing.md)
 

--- a/docs/architecture/domains/struna-access.md
+++ b/docs/architecture/domains/struna-access.md
@@ -4,6 +4,7 @@
 flowchart TB
   subgraph playback [Playback /stream/slug]
     PP[public]
+    PH[hidden URL-only]
     PR[protected listen token]
     PV[private full auth]
   end
@@ -19,7 +20,8 @@ Playback and control access are **fully independent** per Struna. Plume’s remo
 
 | Mode | Legacy players | Web / Plume |
 |------|----------------|-------------|
-| **public** | `/stream/lofi` | Works |
+| **public** | `/stream/lofi` | Works (anonymous player OK) |
+| **hidden** | `/stream/lofi` (same gate) | Works via shared `/player/{slug}` URL; **not** on listen lists |
 | **protected** | `/stream/lofi?token=...` (MVP) | Session/cookie |
 | **private** | Not compatible (no OIDC in VLC) | Full auth |
 
@@ -45,8 +47,15 @@ Token generated at creation (**Kithara-owned** Struna secret); owner can rotate.
 
 | Path | Filter |
 |------|--------|
-| `GET /api/streams/listen` | Principal may listen (public for all; protected/private → owner **or** grant) |
+| `GET /api/streams/listen` | Principal may listen (**public** for all; **hidden** omitted except owner/grant/control-guest; protected/private → owner **or** grant) |
 | `GET /api/streams/control` | Principal may DJ (owner **or** grant **or** protected-control ephemeral guest for that Struna) |
+
+Unauthenticated open-playback reads (public **or** hidden — URL is enough; no secrets):
+
+| Path | Notes |
+|------|--------|
+| `GET /api/streams/by-slug/{slug}` | Metadata when playback is public/hidden; otherwise `404` |
+| `GET /api/streams/by-slug/{slug}/now-playing` | Same gate; powers anonymous Plume player polls |
 
 Today’s ACL is owner + grant (+ guest for protected control). **Phase 6 contract:** owner-only grant CRUD under `/api/streams/{id}/grants` and managed-user **permission ceiling** enforcement on create / grant mutations — see [auth](../interfaces/auth.md) and [rest-api](../interfaces/rest-api.md). Listen-token holders are gated on `/stream/{slug}` (Phase 5), not via these lists.
 
@@ -102,6 +111,7 @@ Party DJ is still not a durable account — but it **is** a real row in Kithara�
 |----------|---------|----------|
 | public | private | Open radio; owner DJs |
 | public | protected | Party — anyone listens; guests exchange code then queue |
+| hidden | private | Share a player URL; strangers cannot browse it on home |
 | protected | protected | Listen token URL + guest exchange for control |
 | private | private | Fully locked |
 

--- a/docs/architecture/glossary.md
+++ b/docs/architecture/glossary.md
@@ -19,7 +19,7 @@ Dual naming: **codename** (musical instruments theme) + **plain English**. When 
 | **Cauda** | Telegram bot client | Future **user-aware** client: remote Struna control from Telegram chats |
 | **Client module** | User-facing integration | Deployable surface (Plume, Beak, Cauda, …) that calls Kithara REST |
 | **User-aware client** | Login UI module | Client whose end users authenticate with JWT from an auth module (Plume, Cauda) |
-| **Static client** | Bot / keyed UI module | Client with no human Bardie login; uses a **join secret** plus **module-managed users** with per-user credentials (Beak) |
+| **Static client** | Bot / keyed UI module | Client with no human Bardie login; **Registers** with a join secret, then day-to-day `/api` as **module-managed users** (Beak). Module admin → planned mTLS RPCs |
 | **Module-managed user** | Managed user | Alias — see **Managed user** above |
 | **Magpie** | YouTube / ytdl source | MVP: search + play via ytdl; cache-first Tune library; writes PCM to session FIFO |
 | **Starling** | External / local stream source | Future: re-broadcast direct audio input; sparse Tune (URI, no blob) for history/queue |
@@ -39,7 +39,7 @@ Dual naming: **codename** (musical instruments theme) + **plain English**. When 
 | **Listen token** | Playback secret | Query credential for **protected** playback (Kithara-owned) |
 | **Guest code** | Control bootstrap | Short Kithara-owned code **per Struna**; **exchange only** → new ephemeral guest user + Kithara-minted JWTs (rate-limited) |
 | **Guest JWT** | Ephemeral session token | Kithara-signed Bearer (+ refresh) for an ephemeral guest user; Struna-scoped control |
-| **Join secret** | Module credential | Long-lived secret in Kithara/Compose config — registers source/auth/client modules and (for static clients) administers managed users. One credential class (not a separate “bot token”). |
+| **Join secret** | Module credential | Long-lived secret in Kithara/Compose config — **Register bootstrap** for source/auth/client modules. Not a standing `/api` admin key; static managed-user admin is planned as mTLS client→host RPCs. |
 | **Search result cache** | Playable search refs | Global search results retained per principal so they can play/queue by ref; guests cleared on Struna teardown; durable/managed until next search or configurable timeout |
 | **Blob storage** | Library object store | Kithara-owned pluggable backend for Tune bytes (local volume, S3-compatible, WebDAV later) |
 | **Storage key** | Opaque blob id | Durable pointer on a Tune; drivers resolve to file/object — not a host path |

--- a/docs/architecture/interfaces/auth.md
+++ b/docs/architecture/interfaces/auth.md
@@ -8,9 +8,9 @@ Clients authenticate through **Kithara**, not by calling auth adapters on the pu
 |-------|-----------|--------------|-----|
 | **Login JWT** (+ refresh) | Auth module (issue or forward) | Kithara via module JWKS | Durable users (Bes/Argus/…) |
 | **Ephemeral guest JWT** (+ refresh) | **Kithara** | Kithara via its signing key | Guest-code joiners on a protected-control Struna |
-| **Managed-user credentials** | Static client admin flow (join secret) | Kithara | Beak-style tenancy users |
+| **Managed-user credentials** | Static client admin (future mTLS RPCs mint/reset) | Kithara | Beak-style tenancy users |
 
-Kithara does **not** mint auth-module **login** JWTs. It **does** mint JWTs for **ephemeral guest users** after guest-code exchange. **Join secrets** authenticate modules (register + static admin) — not end-user credentials.
+Kithara does **not** mint auth-module **login** JWTs. It **does** mint JWTs for **ephemeral guest users** after guest-code exchange. **Join secrets** bootstrap module `Register` (then Heartbeat is mTLS) — not end-user credentials and **not** standing static-module admin on `/api`.
 
 ```mermaid
 sequenceDiagram
@@ -79,7 +79,7 @@ Each exchange = **one new ephemeral guest user** for that joiner, scoped to the 
 | Ephemeral guest JWT / refresh | **Kithara** (mint) | Guest joiners after code exchange. Signing key: env if set, else auto-generated + persisted |
 | Guest code | **Kithara** (on Struna) | Bootstrap only — exchange for ephemeral guest session |
 | Listen token | **Kithara** (on Struna) | Protected playback `/stream/{slug}?token=` (no exchange) |
-| **Join secret** | **Kithara** config | Module identity — `Register`, heartbeats, static managed-user admin |
+| **Join secret** | **Kithara** config | Module identity — `Register` bootstrap only (Heartbeat = mTLS). Static managed-user **admin** → future mTLS client→host RPCs, not this secret on HTTP |
 
 ## User kinds (one DB)
 
@@ -100,7 +100,7 @@ Every client module **Registers over gRPC** like any other module ([grpc-module-
 | Mode | Meaning | Credential on `/api` |
 |------|---------|----------------------|
 | **user-aware** | End users log in | Bearer **login JWT** from an auth module |
-| **static** | Owns many **managed users** | **Join secret** (admin only) + **per-user credentials** (day-to-day) |
+| **static** | Owns many **managed users** | **Per-user credentials** for day-to-day `/api`; module admin via future **mTLS** RPCs |
 
 See [clients](../domains/clients.md).
 
@@ -134,7 +134,7 @@ See [clients](../domains/clients.md).
 
 ## Join secrets
 
-Long-lived secrets in Kithara config for **every** module (source, auth, client). Same credential authenticates `Register` / heartbeats at **container startup** and, for **static** clients, managed-user admin. Ordinary Struna/API work for static modules still uses each managed user’s own credentials.
+Long-lived secrets in Kithara config for **every** module (source, auth, client). They authenticate **`Register` only** (bootstrap before mTLS). **Heartbeat** and later work/admin RPCs use the module client cert. Ordinary Struna/API work for static modules uses each managed user’s own credentials — never the join secret on `/api`.
 
 **Related:** [domains/auth-adapters.md](../domains/auth-adapters.md) · [grpc-auth-adapter.md](grpc-auth-adapter.md) · [struna-access](../domains/struna-access.md) · [ADR 007](../adrs/007-auth-adapter-modules.md)
 

--- a/docs/architecture/interfaces/grpc-module-registry.md
+++ b/docs/architecture/interfaces/grpc-module-registry.md
@@ -123,6 +123,8 @@ Work RPCs live on **per-kind contracts** the module hosts at `grpc_advertise_add
 
 Same `Register` as everyone else: join secret + `kind=client` + optional `ClientRegisterDetails` (`user-aware` \| `static` + permission ceiling when static). Day-to-day Struna control still uses REST `/api` — see [clients](../domains/clients.md).
 
+**Locked:** all clients use Registry `Register` + `Heartbeat` only for mesh membership. There are **no** day-to-day client work RPCs. **Static** clients will get **client→host managed-user admin** RPCs (mTLS slug identity) when Beak needs them — **not** join-secret admin on `/api`. User-aware clients (Plume) never need that surface.
+
 ## Observability
 
 Each work RPC is its own client call from Kithara → module: propagate W3C `traceparent`, record module slug + RPC name. Module OTel names stay `bardie.source.*` / `bardie.auth.*` / `bardie.plume` (etc.).

--- a/docs/architecture/interfaces/http-stream-output.md
+++ b/docs/architecture/interfaces/http-stream-output.md
@@ -19,10 +19,17 @@ sequenceDiagram
 Content-Type: audio/mpeg
 icy-name: Friday Night Jazz
 icy-genre: Bardie
+```
+
+When the client sends `Icy-MetaData: 1` (VLC / most legacy players), also:
+
+```
 icy-metaint: 8192
 ```
 
 Inline metadata blocks: `StreamTitle='Artist - Title';`
+
+Clients that **omit** `Icy-MetaData: 1` (HTML5 `<audio>`, many browsers) receive **plain MP3** with no in-band blocks — browsers decode ICY bytes as audio and stutter.
 
 ## Auth by playback mode
 

--- a/docs/architecture/interfaces/rest-api.md
+++ b/docs/architecture/interfaces/rest-api.md
@@ -16,8 +16,10 @@ Client-facing HTTP API on Kithara (any client module). Base path: `/api`.
 | Caller | Credential on `/api` |
 |--------|----------------------|
 | User-aware clients | Bearer **user JWT** from an auth module |
-| Static clients | **Per-user credentials** for day-to-day; **join secret** only for managed-user admin |
+| Static clients | **Per-user credentials** for day-to-day — **no** join secret on `/api` |
 | Protected-control guests | Bearer **ephemeral guest JWT** after code exchange (Kithara-minted for a new ephemeral guest user) |
+
+Managed-user **admin** (create/list/revoke, credential mint/reset) is **not** a REST `/api` surface. Locked destination: **mTLS client→host** gRPC for static modules only — see [clients](../domains/clients.md).
 
 See [auth.md](auth.md).
 

--- a/docs/architecture/interfaces/rest-api.md
+++ b/docs/architecture/interfaces/rest-api.md
@@ -49,8 +49,10 @@ Wire paths stay English (`/api/streams`); product language is **Struna**.
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/streams/listen` | List Strunas the principal may **listen** to (owner + grant; public for everyone) |
+| GET | `/api/streams/listen` | List Strunas the principal may **listen** to (public for everyone; **hidden** omitted except owner/grant/control-guest; protected/private → owner + grant) |
 | GET | `/api/streams/control` | List Strunas the principal may **control** (owner + grant + protected-control guest) |
+| GET | `/api/streams/by-slug/{slug}` | **Unauthenticated.** Metadata when playback is **public** or **hidden**; else `404` |
+| GET | `/api/streams/by-slug/{slug}/now-playing` | **Unauthenticated.** Same open-playback gate as above |
 | POST | `/api/streams` | Create **encode-alive**: slug unique among alive Strunas, session FIFO, silence + FFmpeg, guest code; listen token when playback is protected |
 | GET | `/api/streams/{id}` | Get by internal GUID (listen **or** control ACL) |
 | POST | `/api/streams/{id}/pause` | Pause: silence feeder on + optional module `PauseTrack` (idempotent) |

--- a/docs/architecture/interfaces/rest-api.md
+++ b/docs/architecture/interfaces/rest-api.md
@@ -39,6 +39,7 @@ Kithara verifies **login** JWTs via module JWKS; it does not mint them. It **doe
 | Method | Path | Description |
 |--------|------|-------------|
 | POST | `/api/streams/{id}/guest/exchange` | **Unauthenticated** bootstrap. Body: short guest code → create **ephemeral guest user** + Kithara-signed JWT (+ refresh) |
+| POST | `/api/streams/by-slug/{slug}/guest/exchange` | Same as above; slug for client UX (code stays out of the URL) |
 
 Rate-limit (GUEST-XCHG-001): fixed window per IP + Struna; failures → `429` (failure lockout polish → Phase 8). Each exchange creates a **new** ephemeral guest user for that joiner (Struna-scoped; destroyed with the Struna). Do not send the guest code on every request. Details: [struna-access](../domains/struna-access.md).
 

--- a/docs/architecture/interfaces/uri-routing.md
+++ b/docs/architecture/interfaces/uri-routing.md
@@ -19,7 +19,7 @@ flowchart TB
 | `/` | Plume (optional) | Auth required when Plume is used |
 | `/control/{slug}` | Plume (optional) | Per Struna **control** mode — remote control desk |
 | `/player/{slug}` | Plume (optional) | Per Struna **playback** mode — listen / player surface |
-| `/api/*` | Kithara REST (incl. auth + `…/guest/exchange` + global search) | Login JWT; ephemeral guest JWT; join secret only for static-module admin |
+| `/api/*` | Kithara REST (incl. auth + `…/guest/exchange` + global search) | Login JWT; ephemeral guest JWT; static **per-user** creds — **not** join secret |
 | `/stream/{slug}` | Kithara Stream Server | Per Struna playback mode |
 
 gRPC (`:5000`) is **not** on this map — modules reach Kithara on the internal network only. Auth adapters are never public edge targets.

--- a/docs/architecture/mvp/known-issues.md
+++ b/docs/architecture/mvp/known-issues.md
@@ -12,6 +12,7 @@ IDs use `SURFACE-TOPIC-NNN` (see [security-audit ID scheme](security-audit.md#id
 |----|-----|---------|----------|
 | [NECK-PCM-001](#neck-pcm-001--canonical-pcm-format-constants-are-duplicated) | P2 | Session PCM rate/channels hard-coded in several places | [kithara#25](https://github.com/Bardie-radio/kithara/issues/25) |
 | [NECK-SWP-001](#neck-swp-001--orphan-writer-sweep-runs-on-every-play-including-new-strunas) | P2 | `StopOrphanWriters` / `StopTracksForStruna` on the hot play path | [kithara#26](https://github.com/Bardie-radio/kithara/issues/26) |
+| [STREAM-ACL-001](#stream-acl-001--protected-canlisten-ignores-listen-token-holders) | P3 | `CanListen` / listen list for **protected** are owner+grant only; token holders are stream-only today | backlog |
 
 ---
 
@@ -61,6 +62,22 @@ That bulk cancel exists because Neck can lose `track_job_id` while Magpie still 
 2. Keep Struna-scoped cancel for rare recovery (delete / proven desync / skip with unknown orphans), not every `play`.
 3. Harden job-map / TrackStatus continuity (NECK-JOB-001) so orphans become exceptional.
 4. Demote or drop `StopTracksForStruna` from the common contract once Neck no longer needs it for play.
+
+---
+
+## STREAM-ACL-001 — Protected `CanListen` ignores listen-token holders
+
+**Severity:** P3 (design gap; stream gate is correct)  
+**Component:** `StrunaAccess.CanListen` / `AppearsOnListenList` vs Stream Server  
+**Owner:** Phase 8 / access-model polish
+
+**Tracking:** backlog (no GitHub issue yet)
+
+Protected playback is **token-based** on `/stream/{slug}?token=…` ([struna-access](../domains/struna-access.md)). REST `CanListen` / listen-list membership today only check **owner + control grant** — same as private for list purposes. Holders of the listen token can play audio but do not appear as “may listen” principals on GUID discover / home lists, and Plume cannot treat “I have the token” as session ACL without a Bearer exchange (intentionally omitted for legacy players).
+
+**Failure mode (design):** token-only listeners are second-class on REST surfaces; any future “listenable to me” UX that keys off `CanListen` under-counts them.
+
+**Remediation sketch (later):** decide whether listen-token capability should ever mint a short-lived listen principal, stay stream-only forever, or get a separate discovery path — do not silently widen `CanListen` to “everyone with the query param” on authenticated REST.
 
 ---
 

--- a/docs/architecture/operations/deployment.md
+++ b/docs/architecture/operations/deployment.md
@@ -63,6 +63,7 @@ Drop a module on the Compose network with its **join secret** and it registers. 
 
 - Ready when HTTP responds and gRPC accepts registrations.
 - Stopping the container tears down alive Struna encoders and open stream connections.
+- **Restart:** Struna **rows** (and queues) live in the DB; encode sessions do not. On startup Neck **rehydrates** FIFO + silence + FFmpeg for every DB Struna so `/stream/{slug}` and play work again without recreating the Struna.
 - Horizontal multi-instance Kithara is **out of MVP scope**.
 
 ## Related

--- a/src/Kithara/Features/Library/TuneLibrary.cs
+++ b/src/Kithara/Features/Library/TuneLibrary.cs
@@ -88,6 +88,31 @@ public sealed class TuneLibrary
         return new EnsureTuneResult(existing.Id, Created: false);
     }
 
+    /// <summary>Lookup by module + external id (or raw track ref) for now-playing artwork enrichment.</summary>
+    public async Task<Tune?> FindByModuleRefAsync(
+        string moduleSlug,
+        string trackRef,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(moduleSlug) || string.IsNullOrWhiteSpace(trackRef))
+        {
+            return null;
+        }
+
+        var slug = moduleSlug.Trim().ToLowerInvariant();
+        var externalId = trackRef.Trim();
+
+        await using var db = await _dbContextFactory
+            .CreateDbContextAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return await db.Tunes.AsNoTracking()
+            .FirstOrDefaultAsync(
+                t => t.ModuleSlug == slug && t.ExternalId == externalId,
+                cancellationToken)
+            .ConfigureAwait(false);
+    }
+
     private static string? NullIfWhiteSpace(string? value) =>
         string.IsNullOrWhiteSpace(value) ? null : value.Trim();
 

--- a/src/Kithara/Features/Streaming/StreamEndpoints.cs
+++ b/src/Kithara/Features/Streaming/StreamEndpoints.cs
@@ -121,6 +121,8 @@ public static class StreamEndpoints
         switch (struna.PlaybackAccess)
         {
             case PlaybackAccess.Public:
+            case PlaybackAccess.Hidden:
+                // URL is enough — hidden is list-omitted, not stream-gated.
                 return true;
 
             case PlaybackAccess.Protected:
@@ -150,7 +152,7 @@ public static class StreamEndpoints
 
                 var principal = await AuthPrincipal.ResolveAsync(http.User, persistence, authHarness, ct)
                     .ConfigureAwait(false);
-                if (principal is null || !StrunaAccess.CanListen(struna, principal.UserId))
+                if (principal is null || !StrunaAccess.CanListen(struna, principal))
                 {
                     http.Response.StatusCode = StatusCodes.Status403Forbidden;
                     await http.Response.WriteAsJsonAsync(new { error = "forbidden" }, ct)

--- a/src/Kithara/Features/Streaming/StreamEndpoints.cs
+++ b/src/Kithara/Features/Streaming/StreamEndpoints.cs
@@ -59,29 +59,56 @@ public static class StreamEndpoints
         http.Response.Headers.CacheControl = "no-cache";
         http.Response.Headers["icy-name"] = struna.Title;
         http.Response.Headers["icy-genre"] = "Bardie";
-        http.Response.Headers["icy-metaint"] = IcyMetaInt.ToString();
         http.Response.Headers.Append("Accept-Ranges", "none");
+
+        // Icecast convention: inject in-band metadata only when the client asks.
+        // VLC sends Icy-MetaData: 1; HTML5 <audio> does not — browsers treat ICY
+        // blocks as audio and stutter ("underfed"). Plain MP3 for everyone else.
+        var wantIcy = WantsIcyMetadata(http.Request);
+        if (wantIcy)
+        {
+            http.Response.Headers["icy-metaint"] = IcyMetaInt.ToString();
+        }
 
         // Disable response buffering so listeners hear live audio.
         var feature = http.Features.Get<Microsoft.AspNetCore.Http.Features.IHttpResponseBodyFeature>();
         feature?.DisableBuffering();
 
-        await using var icy = new IcyMetadataStream(
-            http.Response.Body,
-            () => neck.GetStreamTitle(struna.Id),
-            IcyMetaInt);
-
         try
         {
-            await foreach (var chunk in session.Fanout.SubscribeAsync(ct).ConfigureAwait(false))
+            if (wantIcy)
             {
-                await icy.WriteAudioAsync(chunk, ct).ConfigureAwait(false);
+                await using var icy = new IcyMetadataStream(
+                    http.Response.Body,
+                    () => neck.GetStreamTitle(struna.Id),
+                    IcyMetaInt);
+
+                await foreach (var chunk in session.Fanout.SubscribeAsync(ct).ConfigureAwait(false))
+                {
+                    await icy.WriteAudioAsync(chunk, ct).ConfigureAwait(false);
+                }
+            }
+            else
+            {
+                await foreach (var chunk in session.Fanout.SubscribeAsync(ct).ConfigureAwait(false))
+                {
+                    await http.Response.Body.WriteAsync(chunk, ct).ConfigureAwait(false);
+                    await http.Response.Body.FlushAsync(ct).ConfigureAwait(false);
+                }
             }
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {
             // Listener disconnected.
         }
+    }
+
+    /// <summary>True when the client opts into SHOUTcast/Icecast in-band metadata.</summary>
+    private static bool WantsIcyMetadata(HttpRequest request)
+    {
+        var value = request.Headers["Icy-MetaData"].FirstOrDefault()
+            ?? request.Headers["Icy-Metadata"].FirstOrDefault();
+        return string.Equals(value, "1", StringComparison.Ordinal);
     }
 
     private static async Task<bool> AuthorizePlaybackAsync(

--- a/src/Kithara/Features/Streams/StrunaAccess.cs
+++ b/src/Kithara/Features/Streams/StrunaAccess.cs
@@ -10,6 +10,13 @@ namespace Kithara.Features.Streams;
 public static class StrunaAccess
 {
     /// <summary>
+    /// True when playback needs no listen token and no Bearer on <c>/stream/{slug}</c>
+    /// (URL is enough — includes <see cref="PlaybackAccess.Hidden"/>).
+    /// </summary>
+    public static bool IsOpenPlayback(PlaybackAccess access) =>
+        access is PlaybackAccess.Public or PlaybackAccess.Hidden;
+
+    /// <summary>
     /// True when the principal may DJ this Struna (play / queue / skip / pause / delete).
     /// </summary>
     public static bool CanControl(Struna struna, AuthUserRecord principal)
@@ -35,19 +42,31 @@ public static class StrunaAccess
     }
 
     /// <summary>
-    /// True when the principal may discover this Struna as listenable via REST.
+    /// True when the principal may listen / use GUID discover routes.
+    /// Hidden is listenable like public (URL is enough); listing is gated separately.
     /// Actual <c>/stream/{slug}</c> gates (listen token) are Stream Server.
     /// </summary>
-    public static bool CanListen(Struna struna, Guid principalUserId) =>
+    public static bool CanListen(Struna struna, AuthUserRecord principal) =>
         struna.PlaybackAccess switch
         {
             PlaybackAccess.Public => true,
+            PlaybackAccess.Hidden => true,
             PlaybackAccess.Protected =>
-                struna.OwnerUserId == principalUserId
-                || struna.ControlGrants.Any(g => g.UserId == principalUserId),
+                // STREAM-ACL-001 — listen-token holders are stream-gated only today (not REST CanListen).
+                struna.OwnerUserId == principal.UserId
+                || struna.ControlGrants.Any(g => g.UserId == principal.UserId),
             PlaybackAccess.Private =>
-                struna.OwnerUserId == principalUserId
-                || struna.ControlGrants.Any(g => g.UserId == principalUserId),
+                struna.OwnerUserId == principal.UserId
+                || struna.ControlGrants.Any(g => g.UserId == principal.UserId),
             _ => false,
         };
+
+    /// <summary>
+    /// <c>GET /api/streams/listen</c> visibility. Hidden is omitted from the public browse list —
+    /// only owner, grants, and guests who already control that Struna see it there.
+    /// </summary>
+    public static bool AppearsOnListenList(Struna struna, AuthUserRecord principal) =>
+        struna.PlaybackAccess == PlaybackAccess.Hidden
+            ? CanControl(struna, principal)
+            : CanListen(struna, principal);
 }

--- a/src/Kithara/Features/Streams/StrunaAccessFilters.cs
+++ b/src/Kithara/Features/Streams/StrunaAccessFilters.cs
@@ -124,7 +124,7 @@ internal static class StrunaResourceGate
         {
             var allowed = requireControl
                 ? StrunaAccess.CanControl(struna, principal)
-                : StrunaAccess.CanListen(struna, principal.UserId) || StrunaAccess.CanControl(struna, principal);
+                : StrunaAccess.CanListen(struna, principal) || StrunaAccess.CanControl(struna, principal);
 
             if (!allowed)
             {

--- a/src/Kithara/Features/Streams/StrunaEndpoints.cs
+++ b/src/Kithara/Features/Streams/StrunaEndpoints.cs
@@ -27,6 +27,8 @@ public static class StrunaEndpoints
         // Bootstrap is unauthenticated (guest code only); GUEST-XCHG-001 rate-limits per IP + Struna.
         root.MapPost("/{id:guid}/guest/exchange", GuestExchangeAsync)
             .RequireRateLimiting("guest-exchange");
+        root.MapPost("/by-slug/{slug}/guest/exchange", GuestExchangeBySlugAsync)
+            .RequireRateLimiting("guest-exchange");
 
         var group = root.MapGroup(string.Empty)
             .RequireAuthorization()
@@ -412,8 +414,42 @@ public static class StrunaEndpoints
             return Results.NotFound(new { error = "not_found" });
         }
 
-        var exchanged = await guests.ExchangeAsync(id, body.GuestCode ?? body.Code!, ct)
+        return await CompleteGuestExchangeAsync(id, body.GuestCode ?? body.Code!, guests, ct)
             .ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Slug-based exchange for client UX (share <c>/control/{slug}</c>; code stays out of the URL).
+    /// </summary>
+    private static async Task<IResult> GuestExchangeBySlugAsync(
+        string slug,
+        [FromBody] GuestExchangeBody body,
+        Neck neck,
+        GuestJwtService guests,
+        CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(body.GuestCode ?? body.Code))
+        {
+            return Results.BadRequest(new { error = "guest_code is required." });
+        }
+
+        var struna = await neck.GetStrunaBySlugAsync(slug, ct).ConfigureAwait(false);
+        if (struna is null)
+        {
+            return Results.NotFound(new { error = "not_found" });
+        }
+
+        return await CompleteGuestExchangeAsync(struna.Id, body.GuestCode ?? body.Code!, guests, ct)
+            .ConfigureAwait(false);
+    }
+
+    private static async Task<IResult> CompleteGuestExchangeAsync(
+        Guid strunaId,
+        string guestCode,
+        GuestJwtService guests,
+        CancellationToken ct)
+    {
+        var exchanged = await guests.ExchangeAsync(strunaId, guestCode, ct).ConfigureAwait(false);
         if (exchanged is null)
         {
             return Results.Json(new { error = "invalid_guest_code" }, statusCode: StatusCodes.Status401Unauthorized);

--- a/src/Kithara/Features/Streams/StrunaEndpoints.cs
+++ b/src/Kithara/Features/Streams/StrunaEndpoints.cs
@@ -30,6 +30,10 @@ public static class StrunaEndpoints
         root.MapPost("/by-slug/{slug}/guest/exchange", GuestExchangeBySlugAsync)
             .RequireRateLimiting("guest-exchange");
 
+        // Open playback (public | hidden): no Bearer — shared player URL is enough.
+        root.MapGet("/by-slug/{slug}", GetOpenBySlugAsync);
+        root.MapGet("/by-slug/{slug}/now-playing", NowPlayingBySlugAsync);
+
         var group = root.MapGroup(string.Empty)
             .RequireAuthorization()
             .AddEndpointFilter<RequirePrincipalFilter>();
@@ -67,7 +71,7 @@ public static class StrunaEndpoints
     }
 
     private static Task<IResult> ListListenAsync(HttpContext http, Neck neck, CancellationToken ct) =>
-        ListFilteredAsync(http, neck, ct, (s, p) => StrunaAccess.CanListen(s, p.UserId));
+        ListFilteredAsync(http, neck, ct, StrunaAccess.AppearsOnListenList);
 
     private static Task<IResult> ListControlAsync(HttpContext http, Neck neck, CancellationToken ct) =>
         ListFilteredAsync(http, neck, ct, StrunaAccess.CanControl);
@@ -210,6 +214,39 @@ public static class StrunaEndpoints
         MapPlayResult(await neck.SkipAsync(id, ct).ConfigureAwait(false));
 
     private static async Task<IResult> NowPlayingAsync(
+        Guid id,
+        Neck neck,
+        TuneLibrary tunes,
+        CancellationToken ct) =>
+        await BuildNowPlayingResultAsync(id, neck, tunes, ct).ConfigureAwait(false);
+
+    private static async Task<IResult> GetOpenBySlugAsync(string slug, Neck neck, CancellationToken ct)
+    {
+        var struna = await neck.GetStrunaBySlugAsync(slug, ct).ConfigureAwait(false);
+        if (struna is null || !StrunaAccess.IsOpenPlayback(struna.PlaybackAccess))
+        {
+            return Results.NotFound(new { error = "not_found" });
+        }
+
+        return Results.Ok(MapStruna(struna));
+    }
+
+    private static async Task<IResult> NowPlayingBySlugAsync(
+        string slug,
+        Neck neck,
+        TuneLibrary tunes,
+        CancellationToken ct)
+    {
+        var struna = await neck.GetStrunaBySlugAsync(slug, ct).ConfigureAwait(false);
+        if (struna is null || !StrunaAccess.IsOpenPlayback(struna.PlaybackAccess))
+        {
+            return Results.NotFound(new { error = "not_found" });
+        }
+
+        return await BuildNowPlayingResultAsync(struna.Id, neck, tunes, ct).ConfigureAwait(false);
+    }
+
+    private static async Task<IResult> BuildNowPlayingResultAsync(
         Guid id,
         Neck neck,
         TuneLibrary tunes,
@@ -672,6 +709,7 @@ public static class StrunaEndpoints
         {
             "protected" => PlaybackAccess.Protected,
             "private" => PlaybackAccess.Private,
+            "hidden" => PlaybackAccess.Hidden,
             _ => PlaybackAccess.Public,
         };
 

--- a/src/Kithara/Features/Streams/StrunaEndpoints.cs
+++ b/src/Kithara/Features/Streams/StrunaEndpoints.cs
@@ -207,12 +207,40 @@ public static class StrunaEndpoints
     private static async Task<IResult> SkipAsync(Guid id, Neck neck, CancellationToken ct) =>
         MapPlayResult(await neck.SkipAsync(id, ct).ConfigureAwait(false));
 
-    private static IResult NowPlayingAsync(Guid id, Neck neck)
+    private static async Task<IResult> NowPlayingAsync(
+        Guid id,
+        Neck neck,
+        TuneLibrary tunes,
+        CancellationToken ct)
     {
         var now = neck.GetNowPlaying(id);
         if (now is null)
         {
             return Results.Ok(new { playing = false });
+        }
+
+        var artworkUrl = now.ArtworkUrl;
+        var title = now.Title;
+        var artist = now.Artist;
+        if (string.IsNullOrWhiteSpace(artworkUrl)
+            || string.IsNullOrWhiteSpace(title)
+            || string.IsNullOrWhiteSpace(artist))
+        {
+            var tune = await tunes
+                .FindByModuleRefAsync(now.ModuleSlug, now.TrackRef, ct)
+                .ConfigureAwait(false);
+            if (tune is not null)
+            {
+                artworkUrl = string.IsNullOrWhiteSpace(artworkUrl) ? tune.ArtworkUrl : artworkUrl;
+                title = string.IsNullOrWhiteSpace(title) ? tune.Title : title;
+                artist = string.IsNullOrWhiteSpace(artist) ? tune.Artist : artist;
+            }
+        }
+
+        var streamTitle = BuildStreamTitle(artist, title);
+        if (string.IsNullOrWhiteSpace(streamTitle))
+        {
+            streamTitle = now.StreamTitle;
         }
 
         return Results.Ok(new
@@ -222,10 +250,28 @@ public static class StrunaEndpoints
             module = now.ModuleSlug,
             track_ref = now.TrackRef,
             track_job_id = now.TrackJobId,
-            title = now.Title,
-            artist = now.Artist,
-            stream_title = now.StreamTitle,
+            title,
+            artist,
+            stream_title = streamTitle,
+            artwork_url = artworkUrl,
         });
+    }
+
+    private static string BuildStreamTitle(string? artist, string? title)
+    {
+        var hasArtist = !string.IsNullOrWhiteSpace(artist);
+        var hasTitle = !string.IsNullOrWhiteSpace(title);
+        if (hasArtist && hasTitle)
+        {
+            return $"{artist!.Trim()} - {title!.Trim()}";
+        }
+
+        if (hasTitle)
+        {
+            return title!.Trim();
+        }
+
+        return hasArtist ? artist!.Trim() : string.Empty;
     }
 
     private static async Task<IResult> ListQueueAsync(Guid id, Neck neck, CancellationToken ct)
@@ -328,7 +374,7 @@ public static class StrunaEndpoints
                     hit.Title,
                     hit.Artist,
                     null,
-                    null,
+                    ArtworkFromHit(hit),
                     null,
                     null,
                     null),
@@ -602,6 +648,17 @@ public static class StrunaEndpoints
 
     private static Guid? ParseGuid(string? value) =>
         Guid.TryParse(value, out var id) ? id : null;
+
+    private static string? ArtworkFromHit(CachedSearchHit hit)
+    {
+        if (hit.Metadata.TryGetValue("artwork_url", out var url)
+            && !string.IsNullOrWhiteSpace(url))
+        {
+            return url.Trim();
+        }
+
+        return null;
+    }
 
     public sealed class CreateStrunaBody
     {

--- a/src/Kithara/Infrastructure/Neck/Neck.Models.cs
+++ b/src/Kithara/Infrastructure/Neck/Neck.Models.cs
@@ -14,10 +14,11 @@ public sealed record NowPlayingSnapshot(
     string TrackJobId,
     string? Title,
     string? Artist,
-    bool Paused)
+    bool Paused,
+    string? ArtworkUrl = null)
 {
     public NowPlayingInfo ToInfo() =>
-        new(ModuleSlug, TrackRef, TrackJobId, Title, Artist, Paused);
+        new(ModuleSlug, TrackRef, TrackJobId, Title, Artist, Paused, ArtworkUrl);
 }
 
 public sealed record NowPlayingInfo(
@@ -26,7 +27,8 @@ public sealed record NowPlayingInfo(
     string TrackJobId,
     string? Title,
     string? Artist,
-    bool Paused)
+    bool Paused,
+    string? ArtworkUrl = null)
 {
     /// <summary>ICY / REST display title: <c>Artist - Title</c>; empty when unknown (never raw trackRef).</summary>
     public string StreamTitle

--- a/src/Kithara/Infrastructure/Neck/Neck.Playback.cs
+++ b/src/Kithara/Infrastructure/Neck/Neck.Playback.cs
@@ -65,6 +65,9 @@ public sealed partial class Neck
         }
 
         // Keep encoder; silence fills the gap until TrackStatus Running (module writing PCM).
+        // After host restart the DB row exists but the encode session may not — restore first.
+        await EnsureEncodeAliveAsync(strunaId, struna.Slug, recreateFifo: false, cancellationToken)
+            .ConfigureAwait(false);
         _encoder.SetSilence(strunaId, true);
 
         var fifo = await EnsureStrunaFifoAsync(strunaId, cancellationToken).ConfigureAwait(false);

--- a/src/Kithara/Infrastructure/Neck/Neck.Queue.cs
+++ b/src/Kithara/Infrastructure/Neck/Neck.Queue.cs
@@ -131,13 +131,20 @@ public sealed partial class Neck
             .ConfigureAwait(false);
 
         if (outcome.Ok
-            && (!string.IsNullOrWhiteSpace(next.Tune.Title) || !string.IsNullOrWhiteSpace(next.Tune.Artist)))
+            && (!string.IsNullOrWhiteSpace(next.Tune.Title)
+                || !string.IsNullOrWhiteSpace(next.Tune.Artist)
+                || !string.IsNullOrWhiteSpace(next.Tune.ArtworkUrl)))
         {
             if (_nowPlaying.TryGetValue(strunaId, out var snap))
             {
                 SetNowPlaying(
                     strunaId,
-                    snap with { Title = next.Tune.Title, Artist = next.Tune.Artist });
+                    snap with
+                    {
+                        Title = next.Tune.Title,
+                        Artist = next.Tune.Artist,
+                        ArtworkUrl = next.Tune.ArtworkUrl,
+                    });
             }
         }
 

--- a/src/Kithara/Infrastructure/Neck/Neck.Strunas.cs
+++ b/src/Kithara/Infrastructure/Neck/Neck.Strunas.cs
@@ -108,6 +108,63 @@ public sealed partial class Neck
     }
 
     /// <summary>
+    /// After host restart: DB Strunas are still "alive" but encoders/FIFOs are not.
+    /// Recreate session FIFO + silence + FFmpeg for each row so <c>/stream</c> and play work again.
+    /// </summary>
+    public async Task RehydrateAliveStrunasAsync(CancellationToken cancellationToken = default)
+    {
+        var strunas = await ListStrunasAsync(cancellationToken).ConfigureAwait(false);
+        if (strunas.Count == 0)
+        {
+            return;
+        }
+
+        _logger.LogInformation("Rehydrating encode-alive for {Count} Struna(s)", strunas.Count);
+        foreach (var struna in strunas)
+        {
+            try
+            {
+                await EnsureEncodeAliveAsync(struna.Id, struna.Slug, recreateFifo: true, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(
+                    ex,
+                    "Failed to rehydrate encode session for Struna {Id} ({Slug})",
+                    struna.Id,
+                    struna.Slug);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Ensures silence + FFmpeg are running for an alive Struna (idempotent when already started).
+    /// </summary>
+    public async Task EnsureEncodeAliveAsync(
+        Guid strunaId,
+        string slug,
+        bool recreateFifo = false,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(slug);
+
+        if (_encoder.TryGetSession(strunaId, out _))
+        {
+            return;
+        }
+
+        if (recreateFifo)
+        {
+            // Prior process left a FIFO node with no peers — recreate so RDWR attach is clean.
+            await RemoveStrunaFifoAsync(strunaId, cancellationToken).ConfigureAwait(false);
+        }
+
+        var fifo = await EnsureStrunaFifoAsync(strunaId, cancellationToken).ConfigureAwait(false);
+        await _encoder.StartAsync(strunaId, slug, fifo, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
     /// Tears down a Struna: StopTrack → silence/FFmpeg stop → remove FIFO → destroy guests → free slug.
     /// Returns destroyed guest user ids so Search can clear their result <b>cache</b> (not search history).
     /// </summary>

--- a/src/Kithara/Infrastructure/Neck/NeckServiceCollectionExtensions.cs
+++ b/src/Kithara/Infrastructure/Neck/NeckServiceCollectionExtensions.cs
@@ -29,18 +29,27 @@ public static class NeckServiceCollectionExtensions
     }
 }
 
-/// <summary>Disposes encoder sessions on host shutdown.</summary>
-internal sealed class NeckEncoderHostedService : IHostedService
+/// <summary>
+/// Rehydrates encode-alive sessions from DB Strunas on startup; disposes encoders on shutdown.
+/// </summary>
+internal sealed class NeckEncoderHostedService(
+    Neck neck,
+    StrunaEncoderSupervisor encoder,
+    ILogger<NeckEncoderHostedService> logger) : IHostedService
 {
-    private readonly StrunaEncoderSupervisor _encoder;
-
-    public NeckEncoderHostedService(StrunaEncoderSupervisor encoder)
+    public async Task StartAsync(CancellationToken cancellationToken)
     {
-        _encoder = encoder;
+        try
+        {
+            await neck.RehydrateAliveStrunasAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            // Do not fail host boot — individual Struna failures are logged inside Rehydrate.
+            logger.LogError(ex, "Encode-alive rehydration failed");
+        }
     }
 
-    public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
-
     public async Task StopAsync(CancellationToken cancellationToken) =>
-        await _encoder.DisposeAsync().ConfigureAwait(false);
+        await encoder.DisposeAsync().ConfigureAwait(false);
 }

--- a/src/Kithara/Infrastructure/Persistence/Entities/Struna.cs
+++ b/src/Kithara/Infrastructure/Persistence/Entities/Struna.cs
@@ -5,6 +5,8 @@ public enum PlaybackAccess
     Public = 0,
     Protected = 1,
     Private = 2,
+    /// <summary>Same stream gate as public; omitted from listen lists except owner / control / guest.</summary>
+    Hidden = 3,
 }
 
 public enum ControlAccess

--- a/src/Kithara/Program.cs
+++ b/src/Kithara/Program.cs
@@ -46,11 +46,14 @@ builder.Services.AddRateLimiter(options =>
     options.AddPolicy("guest-exchange", httpContext =>
     {
         var ip = httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
-        var strunaId = httpContext.Request.RouteValues.TryGetValue("id", out var id)
+        // Partition by Struna id (GUID route) or slug (by-slug route).
+        var strunaKey = httpContext.Request.RouteValues.TryGetValue("id", out var id)
             ? id?.ToString() ?? string.Empty
-            : string.Empty;
+            : httpContext.Request.RouteValues.TryGetValue("slug", out var slug)
+                ? slug?.ToString() ?? string.Empty
+                : string.Empty;
         return RateLimitPartition.GetFixedWindowLimiter(
-            $"{ip}:{strunaId}",
+            $"{ip}:{strunaKey}",
             _ => new FixedWindowRateLimiterOptions
             {
                 PermitLimit = 10,

--- a/tests/Kithara.Tests/StrunaAccessTests.cs
+++ b/tests/Kithara.Tests/StrunaAccessTests.cs
@@ -1,0 +1,70 @@
+using Bardie.Harness.Auth.Ports;
+using Kithara.Features.Streams;
+using Kithara.Infrastructure.Persistence.Entities;
+using Xunit;
+
+namespace Kithara.Tests;
+
+public class StrunaAccessTests
+{
+    private static readonly Guid OwnerId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid OtherId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+    private static readonly Guid StrunaId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+
+    [Theory]
+    [InlineData(PlaybackAccess.Public, true)]
+    [InlineData(PlaybackAccess.Hidden, true)]
+    [InlineData(PlaybackAccess.Protected, false)]
+    [InlineData(PlaybackAccess.Private, false)]
+    public void IsOpenPlayback_matches_public_and_hidden(PlaybackAccess access, bool expected) =>
+        Assert.Equal(expected, StrunaAccess.IsOpenPlayback(access));
+
+    [Fact]
+    public void CanListen_public_and_hidden_are_true_for_any_principal()
+    {
+        Assert.True(StrunaAccess.CanListen(MakeStruna(PlaybackAccess.Public), Principal(OtherId)));
+        Assert.True(StrunaAccess.CanListen(MakeStruna(PlaybackAccess.Hidden), Principal(OtherId)));
+    }
+
+    [Fact]
+    public void AppearsOnListenList_hidden_omits_unrelated_users()
+    {
+        var struna = MakeStruna(PlaybackAccess.Hidden);
+        Assert.False(StrunaAccess.AppearsOnListenList(struna, Principal(OtherId)));
+        Assert.True(StrunaAccess.AppearsOnListenList(struna, Principal(OwnerId)));
+        Assert.True(StrunaAccess.AppearsOnListenList(MakeStruna(PlaybackAccess.Public), Principal(OtherId)));
+    }
+
+    [Fact]
+    public void AppearsOnListenList_hidden_includes_control_grantee_and_guest()
+    {
+        var struna = MakeStruna(PlaybackAccess.Hidden, ControlAccess.Protected);
+        struna.ControlGrants.Add(new StrunaControlGrant { StrunaId = StrunaId, UserId = OtherId });
+
+        Assert.True(StrunaAccess.AppearsOnListenList(struna, Principal(OtherId)));
+
+        var guest = new AuthUserRecord(
+            Guid.Parse("33333333-3333-3333-3333-333333333333"),
+            nameof(UserKind.EphemeralGuest),
+            "Active",
+            MustRotateCredentials: false,
+            GuestStrunaId: StrunaId);
+        Assert.True(StrunaAccess.AppearsOnListenList(struna, guest));
+    }
+
+    private static Struna MakeStruna(
+        PlaybackAccess playback,
+        ControlAccess control = ControlAccess.Private) =>
+        new()
+        {
+            Id = StrunaId,
+            Slug = "party",
+            Title = "Party",
+            PlaybackAccess = playback,
+            ControlAccess = control,
+            OwnerUserId = OwnerId,
+        };
+
+    private static AuthUserRecord Principal(Guid userId) =>
+        new(userId, nameof(UserKind.Durable), "Active", MustRotateCredentials: false);
+}


### PR DESCRIPTION
## Summary
- Plume companion: `playback_access=hidden`, anonymous-friendly open playback, slug-based guest exchange, now-playing `artwork_url`, ICY metadata only when `Icy-MetaData: 1`, Neck encode-alive rehydrate after restart
- Docs lock: client managed-user **admin** is future **mTLS client→host** RPCs — not join-secret REST on `/api` (see #31)

Builds on work already merged in #30; this branch carries the remaining commits on `chore/small-fixes`.

## Test plan
- [ ] `dotnet test` (esp. `StrunaAccessTests`)
- [ ] Create Struna with `playback_access=hidden` — listen works; list gated
- [ ] Guest exchange via `/api/streams/by-slug/{slug}/guest/exchange`
- [ ] HTML5 `/stream` without Icy-MetaData stays plain MP3; VLC with header gets ICY
- [ ] Restart host with encode-alive Struna still serving

Related: Plume epic https://github.com/Bardie-radio/plume/pull/10 · backlog https://github.com/Bardie-radio/kithara/issues/31