### PR TITLE
fix: auto-advance queue if nothing is playing currently

### DIFF
--- a/docs/architecture/domains/playback-control.md
+++ b/docs/architecture/domains/playback-control.md
@@ -20,8 +20,8 @@ Bardie uses **live broadcast** semantics ([ADR 001](../adrs/001-broadcast-sync-m
 | **Skip** | `StopTrack` current job → play next queue entry (FFmpeg stays up) |
 | **Pause** | Keep FFmpeg + FIFO + slug; Neck feeds silence |
 | **Delete** | Kill FFmpeg, close FIFO, **free slug**, remove Struna — one teardown (no separate “stop”) |
-| **Queue** | Append a specific track (same body shapes as play) |
-| **Quickqueue** | Quick-search → append first hit |
+| **Queue** | Append a specific track (same body shapes as play). If the Struna is idle (no active track job), also start the queue head — same as Skip from empty now-playing |
+| **Quickqueue** | Quick-search → append first hit (same idle auto-start as Queue) |
 
 Informal **prewarm**: the next module may buffer ahead; no MVP `PrepareTrack` RPC.
 

--- a/src/Kithara/Infrastructure/Neck/Neck.Queue.cs
+++ b/src/Kithara/Infrastructure/Neck/Neck.Queue.cs
@@ -80,6 +80,37 @@ public sealed partial class Neck
             },
             CancellationToken.None);
 
+        // Idle (no active track job): start the queue head so "add to queue" isn't stuck until Skip.
+        // Playing / paused keep a job — append only. Natural track-end clears the job and may leave
+        // a draining now-playing snapshot; enqueue should kick off the next head without a Skip.
+        if (!_jobs.ContainsKey(strunaId))
+        {
+            var gate = Gate(strunaId);
+            await gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                if (!_jobs.ContainsKey(strunaId))
+                {
+                    _encoder.SetSilence(strunaId, true);
+                    try
+                    {
+                        await AdvanceQueueHeadCoreAsync(strunaId, cancellationToken).ConfigureAwait(false);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning(
+                            ex,
+                            "Queue advance failed after idle enqueue on Struna {Id}",
+                            strunaId);
+                    }
+                }
+            }
+            finally
+            {
+                gate.Release();
+            }
+        }
+
         return (entry, null);
     }
 


### PR DESCRIPTION
## Summary
- Auto-advance the Struna queue when nothing is currently playing (`Neck.Queue`).
- Docs tweak in `playback-control.md`.
