### PR TITLE
release: promote publish hardening and queue auto-advance to main

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,6 +7,6 @@
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
 
     <!-- Image / release version (lockstep with GHCR tags). -->
-    <Version>0.1.0</Version>
+    <Version>0.1.1</Version>
   </PropertyGroup>
 </Project>

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,22 +51,24 @@ RUN apk add --no-cache \
       ffmpeg-libavformat \
       ffmpeg-libavutil \
       ffmpeg-libswresample \
-    && mkdir -p /data/mtls /data/db /data/blobs /audio/strunas \
+    && mkdir -p /data/mtls /data/blobs /audio/strunas \
     && chown -R "$APP_UID":"$APP_UID" /data /app /audio
 
 COPY --from=build /app/publish .
 RUN chown -R "$APP_UID":"$APP_UID" /app
 
 USER $APP_UID
-ENV ASPNETCORE_URLS= \
+# Paths default here — Compose only mounts volumes; override env only when relocating.
+# DB: Production requires POSTGRES_HOST (+ USER/PASSWORD/DB); SQLite is Development-only.
+ENV ASPNETCORE_ENVIRONMENT=Production \
+    ASPNETCORE_URLS= \
     BARDIE_GRPC_TLS_DATA_PATH=/data/mtls \
     BARDIE_STRUNA_FIFO_PATH=/audio \
     BARDIE_STORAGE_PATH=/data/blobs \
-    BARDIE_FFMPEG_ROOT=/usr/lib \
-    DbProvider=sqlite \
-    DbConnectionString="Data Source=/data/db/kithara.db"
+    BARDIE_FFMPEG_ROOT=/usr/lib
 
-EXPOSE 8080 5000
+# HTTP only in EXPOSE — module gRPC (:5000) is mesh-internal; do not publish to the host.
+EXPOSE 8080
 # Busybox wget is on Alpine base — avoid curl bloat.
 HEALTHCHECK --interval=30s --timeout=3s --start-period=25s --retries=3 \
   CMD wget -q -O /dev/null http://127.0.0.1:8080/health/live || exit 1

--- a/docs/architecture/domains/playback-control.md
+++ b/docs/architecture/domains/playback-control.md
@@ -20,8 +20,8 @@ Bardie uses **live broadcast** semantics ([ADR 001](../adrs/001-broadcast-sync-m
 | **Skip** | `StopTrack` current job → play next queue entry (FFmpeg stays up) |
 | **Pause** | Keep FFmpeg + FIFO + slug; Neck feeds silence |
 | **Delete** | Kill FFmpeg, close FIFO, **free slug**, remove Struna — one teardown (no separate “stop”) |
-| **Queue** | Append a specific track (same body shapes as play) |
-| **Quickqueue** | Quick-search → append first hit |
+| **Queue** | Append a specific track (same body shapes as play). If the Struna is idle (no active track job), also start the queue head — same as Skip from empty now-playing |
+| **Quickqueue** | Quick-search → append first hit (same idle auto-start as Queue) |
 
 Informal **prewarm**: the next module may buffer ahead; no MVP `PrepareTrack` RPC.
 

--- a/docs/architecture/mvp/README.md
+++ b/docs/architecture/mvp/README.md
@@ -1,9 +1,10 @@
 # MVP
 
-**Phases 1–6 complete.** Next: **Phase 7 (Plume)** and **Phase 8 (Compose + verify)**. Soft residuals from the Phases 4–6 audit live under Phase 8 — see [security-audit.md](security-audit.md). Plan: [implementation-plan.md](implementation-plan.md).
+**Phases 1–6 complete.** Next: **Phase 7 (Plume)** and **Phase 8 (Compose + verify)**. Soft residuals from the Phases 4–6 audit live under Phase 8 — see [security-audit.md](security-audit.md). Plan: [implementation-plan.md](implementation-plan.md). **GHCR release gate:** [pre-publish-audit.md](pre-publish-audit.md).
 
 - [v0.1-scope.md](v0.1-scope.md) — what’s in / out for v0.1
 - [v0.1-milestones.md](v0.1-milestones.md) — short delivery ladder
 - [implementation-plan.md](implementation-plan.md) — ordered work packages, modularity rules, finding → phase map
+- [pre-publish-audit.md](pre-publish-audit.md) — deploy / deps / security re-check / logging before next GHCR publish
 - [security-audit.md](security-audit.md) — mesh + SURFACE-TOPIC findings; Phases 4–6 remediations closed (soft residuals → Phase 8)
 - [known-issues.md](known-issues.md) — non-security footguns (`NECK-*`); Plume-local IDs live in Plume

--- a/docs/architecture/mvp/implementation-plan.md
+++ b/docs/architecture/mvp/implementation-plan.md
@@ -118,9 +118,9 @@ Phase 7 needs Phase 2 + enough of 5–6 (now available). Phase 8 needs MVP apps 
 | META-OTEL-001  | Ops           | Local Compose omits `OTEL_EXPORTER_OTLP_ENDPOINT`                                     | **8** — **Fixed** ([kithara#34](https://github.com/Bardie-radio/kithara/issues/34)) |
 | META-OTEL-002  | Ops           | `Task.Run` drops Activity (Magpie track + Neck encode)                                | **8** — **Fixed** ([kithara#36](https://github.com/Bardie-radio/kithara/issues/36)) |
 | META-OTEL-003  | Ops           | Span attrs / Magpie stages / listen tags lag ADR 008                                  | **8** — **Fixed** (traces; OTLP logs deferred) ([kithara#35](https://github.com/Bardie-radio/kithara/issues/35)) |
-| META-OPS-001   | Ops           | Phase3 sine smoke vs Magpie Release image                                             | **8**                                                                   |
+| META-OPS-001   | Ops           | Phase3 sine smoke vs Magpie Release image                                             | **8 — deferred**                                                        |
 | META-OPS-002   | Ops           | Alpine final images + bare-minimum FFmpeg libs (Kithara/Magpie); Alpine for Plume/Bes | **Done** ([kithara#33](https://github.com/Bardie-radio/kithara/issues/33)) |
-| META-DOC-001   | Docs          | Doc vs code drift (Tune path, Bes ops, Magpie scope, phase status)                    | **8**                                                                   |
+| META-DOC-001   | Docs          | Doc vs code drift (Tune path, Bes ops, Magpie scope, phase status)                    | **8 — deferred**                                                        |
 | MESH-REG-*     | Mesh residual | Join-secret takeover / auto key-on-wire / ephemeral CA                                | Ops + backlog ([security-audit](security-audit.md))                     |
 
 
@@ -421,7 +421,7 @@ libs/                         # host-only
 | **AUTH-ROLE-001**  | **Done** — roles from binding                                                       |
 | **AUTH-JWKS-001**  | **Done** — async JWKS snapshot                                                      |
 | **AUTH-JWKS-002**  | **Done** — Register awaits JWKS; fail-closed rejects Register                       |
-| **GUEST-XCHG-001** | **Partial** — 10/min rate limit; failure lockout **Done** (GUEST-XCHG-002)         |
+| **GUEST-XCHG-001** | **Fixed** — 10/min rate limit + failure lockout (GUEST-XCHG-002); compare GUEST-XCHG-004 Fixed |
 | **AUTH-DISP-001**  | **Done** — unique `User.Username`; `/me` + invite `must_complete_binding` |
 
 
@@ -491,23 +491,24 @@ Do **not** renumber Plume work as “Kithara 7.1 / 7.2”. Satisfies this phase 
 
 ### Work
 
-1. Reference Compose: edge + `plume` + `kithara` + `magpie` + `bes` ([org deployment](https://github.com/Bardie-radio/.github/blob/main/profile/docs/architecture/05-deployment.md)).
-2. `BARDIE_JOIN_SECRETS` for all modules; audio/storage volumes as decided.
-3. Point every app at the **external** OTel collector when you have one (`OTEL_EXPORTER_OTLP_ENDPOINT` + matching Local `compose.otel*.yml` overlay). Unset = no export. [META-OTEL-001](known-issues.md#meta-otel-001--local-compose-omits-otel_exporter_otlp_endpoint) / [kithara#34](https://github.com/Bardie-radio/kithara/issues/34).
-4. Smoke script / checklist: register → login → create → play → listen → skip — **and** a single play trace spanning Plume → Kithara → Magpie. Activity across `Task.Run` (**META-OTEL-002 Fixed**); attrs/stages (**META-OTEL-003 Fixed**, traces only).
+1. **Done** — Reference Compose: edge + `plume` + `kithara` + `magpie` + `bes` ([org deploy](https://github.com/Bardie-radio/.github/tree/main/profile/deploy) · [05-deployment](https://github.com/Bardie-radio/.github/blob/main/profile/docs/architecture/05-deployment.md)).
+2. **Done** — `BARDIE_JOIN_SECRETS` for all modules; audio/storage/Postgres volumes in the reference stack.
+3. Point every app at the **external** OTel collector when you have one (`OTEL_EXPORTER_OTLP_ENDPOINT` in deploy `.env` + Local `compose.otel*.yml` overlay). Unset = no export. [META-OTEL-001](known-issues.md#meta-otel-001--local-compose-omits-otel_exporter_otlp_endpoint) / [kithara#34](https://github.com/Bardie-radio/kithara/issues/34).
+4. Smoke script / checklist: register → login → create → play → listen → skip — **and** a single play trace spanning Plume → Kithara → Magpie. Activity across `Task.Run` (**META-OTEL-002 Fixed**); attrs/stages (**META-OTEL-003 Fixed**, traces only). **OTel E2E continuous-play verify: deferred** (collector wiring documented; live cross-service proof not a Phase 8 gate).
 5. **META-QA-001 Fixed:** Host `WebApplicationFactory` (discovery→`/me`, invite claim→bind, guest exchange, MustRotate gate) + Bes Authenticate/`UpdateUserBinding` + Magpie registry/FIFO pacing/cancel. create→play→FIFO still needs FFmpeg + source module in Compose smoke.
-6. **META-OPS-001:** Align Local phase3 sine smoke with Magpie image config (Debug sine helper vs Release YouTube default) so the documented smoke path is honest.
+6. **META-OPS-001 — deferred:** Align Local phase3 sine smoke with Magpie image config (Debug sine helper vs Release YouTube default). Owner: Local / Magpie docs when next touching phase3 smoke.
 7. **META-OPS-002:** **Done** — Alpine **3.22** finals (`aspnet:10.0-alpine3.22`) for the MVP quartet; Kithara/Magpie install Alpine `ffmpeg-libav*` 6.1 only (no CLI metapackage; pin avoids 3.23+ ffmpeg 8 soname break); `BARDIE_FFMPEG_ROOT`/`MAGPIE_FFMPEG_ROOT=/usr/lib`. See [known-issues](known-issues.md#meta-ops-002--final-images-bloated-ubuntu--full-ffmpeg) / [kithara#33](https://github.com/Bardie-radio/kithara/issues/33).
-8. **META-DOC-001:** Sweep doc drift (library Tune path, Bes operations JWT wording, Magpie Register wording, MVP phase status vs code).
+8. **META-DOC-001 — deferred:** Sweep doc drift (library Tune path, Bes operations JWT wording, Magpie Register wording, MVP phase status vs code). Owner: next doc pass.
 9. **NECK-JOB-001 / NECK-SWP-001 / NECK-PCM-001 Fixed:** TrackStatus reconnect + capped give-up; no orphan sweep on play; shared `CanonicalPcm` ([kithara#26](https://github.com/Bardie-radio/kithara/issues/26), [kithara#25](https://github.com/Bardie-radio/kithara/issues/25)).
-
+10. **Pre-publish (26 Jul 2026):** [pre-publish-audit](pre-publish-audit.md) — **DEPLOY-PLUME-001** (Plume Vite dist on GHCR) is the publish blocker; **META-LOG-001** / **AUTH-FWD-001** / **PLUME-FWD-001** / **META-CFG-001 Fixed** in source (quiet logs + AUTH-INVITE banner, forwarded headers, no demo join secrets in published appsettings).
 
 
 ### Exit criteria
 
-- Documented `docker compose up` path for the MVP quartet.
-- Collector shows a continuous play path across all four `bardie.*` service names (META-OTEL-001/002 closed or explicitly deferred).
-- META-QA-001 / META-OPS-001 / META-OPS-002 / META-DOC-001 / META-OTEL-* closed or explicitly deferred with owners.
+- [x] Documented `docker compose up` path for the MVP quartet ([org deploy](https://github.com/Bardie-radio/.github/tree/main/profile/deploy)).
+- [ ] Collector shows a continuous play path across all four `bardie.*` service names — **deferred** (endpoint + overlays documented; live E2E not required to close Phase 8 reference Compose).
+- META-QA-001 / META-OPS-002 / META-OTEL-001/002/003 **Fixed**; META-OPS-001 / META-DOC-001 / OTel E2E **deferred** with owners above.
+- [ ] GHCR images include Plume Vite `wwwroot/dist` + logging quieting ([pre-publish-audit](pre-publish-audit.md)).
 
 ---
 
@@ -541,7 +542,7 @@ Aligned with [v0.1-scope](v0.1-scope.md):
 - [x] Bes login via unified auth contract; Kithara verifies JWTs  
 - [x] ICY `/stream/{slug}` with metadata; protected listen token  
 - [x] Guest code → ephemeral guest user + JWT; guests die with Struna  
-- [ ] Plume optional; Compose + join secrets; OTel live from Phase 1, verified E2E in Phase 8
+- [x] Plume optional; Compose + join secrets ([org deploy](https://github.com/Bardie-radio/.github/tree/main/profile/deploy)); OTel live from Phase 1 — **E2E continuous-play verify deferred** (Phase 8)
 
 Out of scope stays out: Argus/Hecate, Beak/Cauda, Catbird/Starling, Icecast/HLS primary, multi-instance Kithara, `PrepareTrack`.
 
@@ -585,4 +586,4 @@ Design-review open questions are **closed**. Phase 0 can proceed from the locked
 - [glossary](../glossary.md) · [grpc-module-registry](../interfaces/grpc-module-registry.md) · [grpc-source-module](../interfaces/grpc-source-module.md) · [grpc-blob-storage](../interfaces/grpc-blob-storage.md) · [grpc-library](../interfaces/grpc-library.md) · [auth](../interfaces/auth.md)
 - Org: [05-deployment](https://github.com/Bardie-radio/.github/blob/main/profile/docs/architecture/05-deployment.md)
 
-**Read next:** [security-audit.md](security-audit.md) · Phase 7 Plume · Phase 8 Compose + verify.
+**Read next:** [security-audit.md](security-audit.md) · [pre-publish-audit.md](pre-publish-audit.md) · Phase 7 Plume · Phase 8 Compose + verify.

--- a/docs/architecture/mvp/known-issues.md
+++ b/docs/architecture/mvp/known-issues.md
@@ -17,6 +17,30 @@ IDs use `SURFACE-TOPIC-NNN` (see [security-audit ID scheme](security-audit.md#id
 | [META-OTEL-002](#meta-otel-002--taskrun-drops-activity-context-magpie--neck) | P1 | **Fixed** — ActivityLink across Magpie/Neck `Task.Run` | [kithara#36](https://github.com/Bardie-radio/kithara/issues/36) |
 | [META-OTEL-003](#meta-otel-003--span-attrs--stage-coverage-lag-adr-008) | P2 | **Fixed** (traces/attrs/stages; OTLP logs still optional/deferred) | [kithara#35](https://github.com/Bardie-radio/kithara/issues/35) |
 | [STREAM-ACL-001](#stream-acl-001--protected-canlisten-ignores-listen-token-holders) | P3 | `CanListen` / listen list for **protected** are owner+grant only; token holders are stream-only today | backlog |
+| [DEPLOY-PLUME-001](#deploy-plume-001--ghcr-plume-missing-vite-wwwrootdist) | Blocker | Published Plume image lacks Vite assets until republish | [pre-publish-audit](pre-publish-audit.md) |
+| [META-LOG-001](#meta-log-001--production-log-noise--auth-invite-banner) | P3 | **Fixed** (source) — quiet EF/framework logs; AUTH-INVITE banner | publish required |
+
+---
+
+## DEPLOY-PLUME-001 — GHCR Plume missing Vite `wwwroot/dist`
+
+**Severity:** Blocker for clean `docker compose up` from published images  
+**Component:** Plume Dockerfile / publish / static files  
+**Status:** **Open** until GHCR image includes `wwwroot/dist`
+
+**Tracking:** [pre-publish-audit](pre-publish-audit.md) · local `deploy-test` builds Plume from source as a workaround
+
+Source already runs `npm run build` before `dotnet publish` and serves via `UseStaticFiles`. Older GHCR tags omit dist → empty Content-Type + `nosniff` breaks the UI. Republish Plume after the Dockerfile/csproj fix is on the default branch.
+
+---
+
+## META-LOG-001 — Production log noise + AUTH-INVITE banner
+
+**Severity:** P3 (ops ergonomics)  
+**Component:** Kithara + Plume + Magpie + Bes logging  
+**Status:** **Fixed** in source (26 Jul 2026) — **publish required**
+
+EF Core SQL at Information and broad `Microsoft`/`System` noise buried the registration OTP. Production defaults now raise EF/framework categories to Warning; Kithara logs a multi-line AUTH-INVITE WARNING banner; modules print a short startup banner. Does not log join secrets.
 
 ---
 
@@ -33,9 +57,9 @@ MVP locks the session audio plane to **s16le / 48 kHz / stereo** ([grpc-source-m
 
 | Location | Role |
 |----------|------|
-| `libs/Bardie.Module.Source/FifoAudioSink.cs` | Realtime write pacing |
+| `Bardie.Module.Source` `FifoAudioSink` ([kithara-logos-source](https://github.com/Bardie-radio/kithara-logos-source)) | Realtime write pacing |
 | `src/Kithara/Infrastructure/Neck/SilenceFeeder.cs` | Zero-PCM feed (+ encoder via `CanonicalPcm`) |
-| `libs/Bardie.Module.Source.Debug/SinePcmProof.cs` | Dev sine stream |
+| `Bardie.Module.Source.Debug` `SinePcmProof` ([kithara-logos-source](https://github.com/Bardie-radio/kithara-logos-source)) | Dev sine stream |
 | Magpie `Infrastructure/Media/FfmpegPcmTranscoder.cs` | Decode → FIFO |
 
 Chunk / buffer sizes (e.g. `FifoAudioSink.BufferSize`) remain local I/O knobs.
@@ -155,6 +179,6 @@ Protected playback is **token-based** on `/stream/{slug}?token=…` ([struna-acc
 
 ---
 
-**Related:** [security-audit.md](security-audit.md) · [implementation-plan.md](implementation-plan.md) · [grpc-source-module.md](../interfaces/grpc-source-module.md) · [observability.md](../operations/observability.md)
+**Related:** [pre-publish-audit.md](pre-publish-audit.md) · [security-audit.md](security-audit.md) · [implementation-plan.md](implementation-plan.md) · [grpc-source-module.md](../interfaces/grpc-source-module.md) · [observability.md](../operations/observability.md)
 
-**Read next:** [security-audit.md](security-audit.md)
+**Read next:** [pre-publish-audit.md](pre-publish-audit.md) · [security-audit.md](security-audit.md)

--- a/docs/architecture/mvp/pre-publish-audit.md
+++ b/docs/architecture/mvp/pre-publish-audit.md
@@ -1,0 +1,257 @@
+# Pre-publish audit (MVP GHCR)
+
+**Date:** 2026-07-26  
+**Scope:** End-to-end deploy workflow, external deps, security re-check, logging — before the next published GHCR release of the MVP quartet (`kithara`, `plume`, `magpie`, `bes`).  
+**Mode:** Operators pull `profile/deploy/` Compose + HTTP-only bundled nginx; TLS terminates at an external edge (e.g. Traefik).
+
+This page is the release gate checklist. Living security IDs stay in [security-audit.md](security-audit.md); non-security footguns in [known-issues.md](known-issues.md).
+
+---
+
+## Verdict
+
+**Do not treat** `IMAGE_TAG=latest` **as a clean publish until Plume is rebuilt and pushed** with the Vite `wwwroot/dist` pipeline (Dockerfile `npm run build` + `IncludeViteDist`). Other MVP images look Alpine/ffmpeg-correct for META-OPS-002; Compose + nginx path map is ready. Logging quieting + AUTH-INVITE banner landed in-tree this pass — **require republish** of all four apps to pick them up.
+
+
+| Gate                                    | Status                                                                                           |
+| --------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| Reference Compose + nginx               | Ready ([org](https://github.com/Bardie-radio/.github/tree/main/profile/deploy) `profile/deploy`) |
+| Alpine 3.22 + FFmpeg.AutoGen sonames    | Ready in Dockerfiles (code)                                                                      |
+| Plume static assets in GHCR             | **Blocker** — fix in source; **publish required**                                                |
+| Join secrets / Postgres / PublicBaseUrl | Ready (operator must edit `.env`)                                                                |
+| AUTH-INVITE first boot                  | Ready (OTP in Kithara logs)                                                                      |
+| Security P0 product remediations        | Closed (residuals ops/backlog)                                                                   |
+| Logging Production defaults             | Fixed in source this pass — **publish required**                                                 |
+
+
+---
+
+
+
+## 1) Full deployment workflow
+
+
+
+### Publish path
+
+
+| Repo                           | Workflow                        | Trigger                  | Tag source                                                 | Notes                                                                                                    |
+| ------------------------------ | ------------------------------- | ------------------------ | ---------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| kithara / plume / magpie / bes | `.github/workflows/publish.yml` | `workflow_dispatch` only | `<Version>` in `Directory.Build.props` → SemVer + `latest` | Manual; no auto-publish on merge                                                                         |
+| Same                           | `version-check.yml`             | CI                       | Docs alignment                                             | See org [version-check](https://github.com/Bardie-radio/.github/blob/main/profile/docs/version-check.md) |
+
+
+All four currently declare `<Version>0.1.0</Version>`. Publishing overwrites `0.1.0` and `latest` — coordinate lockstep tags if operators pin SemVer.
+
+### Compose / edge
+
+
+| Artifact                             | Role                                                          | Evidence                                                            |
+| ------------------------------------ | ------------------------------------------------------------- | ------------------------------------------------------------------- |
+| `.github/profile/deploy/compose.yml` | Bundled nginx `:80` + Postgres + quartet                      | GHCR images; gRPC not published                                     |
+| `compose.external-edge.yml`          | Apps only                                                     | Operator supplies Traefik/nginx                                     |
+| `edge/nginx.conf`                    | `/api` `/stream` → kithara; `/` `/control` `/player` → plume  | `X-Forwarded-*` set; HTTP listen only                               |
+| `.env.example`                       | `IMAGE_TAG`, `PUBLIC_BASE_URL`, `JOIN_SECRET_*`, `POSTGRES_*` | Demo placeholders — rotate                                          |
+| `local/deploy-test/`                 | Local mirror                                                  | **Plume** `build:` **from** `../../plume` until GHCR Vite fix lands |
+
+
+
+
+### Plume Vite publish pipeline (blocker)
+
+
+| Step                                                        | In source?               | On GHCR `latest`?      |
+| ----------------------------------------------------------- | ------------------------ | ---------------------- |
+| Dockerfile: Node + `npm ci && npm run build` before publish | Yes (`plume/Dockerfile`) | **No** until republish |
+| `IncludeViteDist` / `NpmBuildSkipped`                       | Yes (`Plume.csproj`)     | Needs publish          |
+| `UseStaticFiles` + no app-level `UseHsts`                   | Yes (`Program.cs`)       | Needs publish          |
+
+
+Symptom without dist: empty/`application/octet-stream` responses + `X-Content-Type-Options: nosniff` → browser blocks CSS/JS.
+
+### Healthchecks / first boot
+
+- Compose healthchecks: busybox `wget` → Kithara `/health/live`, modules `/healthz` (Alpine — no curl).
+- AUTH-INVITE: empty durable DB → `InviteBootstrapHostedService` logs OTP once (WARNING banner after this pass). Claim on Plume `/claim` → Bes bind.
+- Volumes: `bardie-kithara-data` (mTLS CA + blobs), shared `bardie-audio`, Plume `dp-keys`.
+
+
+
+### Deploy findings
+
+
+| ID                   | Sev         | Summary                                                                               | Owner           | Status                                       |
+| -------------------- | ----------- | ------------------------------------------------------------------------------------- | --------------- | -------------------------------------------- |
+| **DEPLOY-PLUME-001** | **Blocker** | Published Plume image missing Vite `wwwroot/dist`                                     | plume (publish) | **Open** until GHCR rebuild                  |
+| **DEPLOY-TAG-001**   | Med         | All repos at `0.1.0`; republish overwrites same SemVer                                | ops / all four  | Ops note                                     |
+| **DEPLOY-DRIFT-001** | Info        | `local/deploy-test` builds Plume from source; org deploy pulls GHCR                   | local           | Intentional until DEPLOY-PLUME-001 closed    |
+| **DEPLOY-ENV-001**   | Med         | Org compose requires `POSTGRES_PASSWORD` / join secrets; local-test has demo defaults | ops             | By design — do not copy demo secrets to prod |
+
+
+---
+
+
+
+## 2) External integrations and dependencies
+
+
+| Dependency                                     | Pin / surface                          | Risk / footgun                                                                                                    |
+| ---------------------------------------------- | -------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| **NuGet** `Bardie.Logos.`* / `Bardie.Module.*` | `0.1.0` on nuget.org                   | Supply-chain: publish Docker builds restore public packages; keep Logos/module SDKs in lockstep with images       |
+| **GHCR** `ghcr.io/bardie-radio/<codename>`     | `workflow_dispatch`                    | Pull needs package read; `latest` moves                                                                           |
+| **Postgres** `postgres:16-alpine`              | Compose                                | Password via `.env`; Kithara `DbProvider=postgres`                                                                |
+| **FFmpeg.AutoGen** `6.1.0.1`                   | Kithara + Magpie                       | **Must** stay on Alpine **3.22** libav sonames (`.58`/`.60`). Floating `10.0-alpine` → 3.23+ ffmpeg 8 breaks load |
+| **YoutubeExplode** `6.6.0`                     | Magpie                                 | YouTube HTML/API drift — runtime failure mode, not image-missing                                                  |
+| **OTLP**                                       | Optional `OTEL_EXPORTER_OTLP_ENDPOINT` | Unset = no export (META-OTEL-001 Fixed)                                                                           |
+| **Browser → edge → Plume/Kithara**             | nginx path map                         | `PUBLIC_BASE_URL` must match browser origin for `<audio>` / CSP `media-src`                                       |
+| **Bes**                                        | Join + work gRPC                       | No public HTTP auth surface; JWTs via Kithara REST/BFF                                                            |
+
+
+
+
+### Integration findings
+
+
+| ID                 | Sev           | Summary                                                                                | Owner             | Status                                  |
+| ------------------ | ------------- | -------------------------------------------------------------------------------------- | ----------------- | --------------------------------------- |
+| **DEP-FFMPEG-001** | High if unpin | Alpine base must remain `aspnet:10.0-alpine3.22`                                       | kithara, magpie   | Mitigated in Dockerfiles (META-OPS-002) |
+| **DEP-YT-001**     | Med           | Magpie YouTube extract can break independently of GHCR                                 | magpie            | Residual / ops                          |
+| **DEP-NUGET-001**  | Low           | Central package versions `0.1.0` — confirm Logos packages published before image build | logos + consumers | Ops checklist                           |
+
+
+---
+
+
+
+## 3) Security re-check
+
+Re-validated against current code (Jul 2026). Detail tables remain in [security-audit.md](security-audit.md).
+
+### Existing findings (status)
+
+
+| ID                                                | Prior           | Re-check              | Evidence                                                           |
+| ------------------------------------------------- | --------------- | --------------------- | ------------------------------------------------------------------ |
+| GUEST-REF-001 … AUTH-CLAIM-001 (P0/P1 closed set) | Fixed           | **Still Fixed**       | Harness / gates / tests present                                    |
+| GUEST-XCHG-001                                    | Partial → Fixed | **Fixed**             | Rate limit + GUEST-XCHG-002 lockout                                |
+| GUEST-XCHG-004                                    | —               | **Fixed** (this pass) | Guest-code compare → `ListenTokenComparer.FixedTimeEquals`         |
+| GUEST-XCHG-003                                    | Open            | **Still open**        | Dual id/slug partitions                                            |
+| MESH-REG-001…004                                  | Open (ops)      | **Still open**        | Auto join-secret takeover residual; Compose keeps `:5000` internal |
+| PLUME-SEC-001/002                                 | Fixed           | **Still Fixed**       | CSP + antiforgery middleware                                       |
+| PLUME-SESS-001                                    | Deferred        | **Still deferred**    | In-memory session store                                            |
+| STREAM-TOK-001                                    | Fixed           | **Still Fixed**       | `ListenTokenComparer.FixedTimeEquals`                              |
+| META-OPS-002 / META-OTEL-*                        | Fixed           | **Still Fixed**       | Dockerfiles + overlays                                             |
+| META-DOC-001 / META-OPS-001                       | Deferred        | **Still deferred**    | Out of this publish gate                                           |
+
+
+
+
+### HSTS / forwarded headers / gRPC / demos
+
+
+| Check                       | Result                                                                                                                                                                                            |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Plume `UseHsts`             | **Removed** from app pipeline (comment: TLS edge owns HSTS)                                                                                                                                       |
+| Kithara/modules HSTS        | Not enabled on HTTP containers                                                                                                                                                                    |
+| `UseForwardedHeaders`       | **Fixed** — Kithara + Plume honor `X-Forwarded-For` / `X-Forwarded-Proto` (**AUTH-FWD-001** / **PLUME-FWD-001**); bundled nginx preserves upstream proto                                          |
+| gRPC `:5000` on public edge | **Not published** in reference nginx                                                                                                                                                              |
+| Demo secrets in templates   | `.env.example` placeholders OK; **Kithara** `appsettings.json` **no longer embeds demo** `BARDIE_JOIN_SECRETS` — Development-only demos; Production requires Compose/env (**META-CFG-001 Fixed**) |
+
+
+
+
+### New / confirmed findings this audit
+
+
+| ID                   | Sev     | Summary                                                                                                                                                                                         | Owner    | Status                                                                                                              |
+| -------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------- |
+| **DEPLOY-PLUME-001** | Blocker | GHCR Plume without Vite dist (MIME/nosniff empty assets)                                                                                                                                        | plume    | Open until publish                                                                                                  |
+| **AUTH-FWD-001**     | P2      | Guest/invite rate limits + lockout use `Connection.RemoteIpAddress` without forwarded-headers → all clients share the edge container IP behind nginx                                            | kithara  | **Fixed** — `UseForwardedHeaders` (publish required)                                                                |
+| **PLUME-FWD-001**    | P2      | Session `Secure = Request.IsHttps` without forwarded proto; behind Traefik→HTTP nginx, app always sees HTTP (works for HTTP demo; Secure cookies wrong if operators expect HTTPS-aware cookies) | plume    | **Fixed** — `UseForwardedHeaders` + nginx proto pass-through (publish required)                                     |
+| **META-CFG-001**     | P3      | Published Kithara image embeds demo join secrets in `appsettings.json`; safe only if Compose/env always overrides                                                                               | kithara  | **Fixed** — removed from base `appsettings.json`; Development-only demos; Compose `.env` still supplies deploy-test |
+| **META-DEPLOY-001**  | P2      | Local `compose.plume.yml` / phase sketches publish `:5000` + demo join secrets                                                                                                                  | local    | **Open** (dev-only)                                                                                                 |
+| **META-LOG-001**     | P3      | EF SQL + framework noise drowned AUTH-INVITE OTP                                                                                                                                                | all four | **Fixed** this pass (source)                                                                                        |
+| **GUEST-XCHG-004**   | P3      | Guest-code ordinal compare                                                                                                                                                                      | kithara  | **Fixed** this pass                                                                                                 |
+
+
+---
+
+
+
+## 4) Logging
+
+
+
+### Before
+
+- Default `Information` + only `Microsoft.AspNetCore: Warning` → **EF Core SQL** (`Microsoft.EntityFrameworkCore.Database.Command`) and other `Microsoft.`* / `System.Net.Http.HttpClient` categories stayed noisy.
+- AUTH-INVITE OTP was a single-line `LogWarning` — easy to miss in compose interleaved logs.
+- Module start lines were one-liners.
+
+
+
+### Implemented this pass (source; needs publish)
+
+
+| Change                                                   | Repos / files                               |
+| -------------------------------------------------------- | ------------------------------------------- |
+| Quieter Logging defaults + `appsettings.Production.json` | kithara, plume, magpie, bes                 |
+| Dev: EF SQL allowed at Information; `DetailedErrors`     | kithara `appsettings.Development.json`      |
+| AUTH-INVITE multi-line WARNING banner                    | `InviteBootstrapHostedService.cs`           |
+| Startup banners                                          | Kithara / Plume / Magpie / Bes `Program.cs` |
+| Plume Dockerfile copies `appsettings.Production.json`    | `plume/Dockerfile`                          |
+
+
+**Not done (intentional):** nginx access_log left default (browser traffic only; healthchecks hit containers directly). Error/Warn app logs kept.
+
+---
+
+
+
+## Publish blockers checklist
+
+Use before declaring the GHCR release good:
+
+- [ ] **plume:** merge Vite/Dockerfile fixes if not on default branch; run **Publish image** workflow; confirm image contains `wwwroot/dist` (or smoke `http://…/` CSS Content-Type)
+- [ ] **kithara / magpie / bes / plume:** publish builds that include logging quieting + banners (this audit’s code changes)
+- [ ] Confirm all four tags match intended `IMAGE_TAG` (SemVer and/or `latest`)
+- [ ] From `profile/deploy`: `cp .env.example .env`, rotate **all** secrets, set `PUBLIC_BASE_URL`
+- [ ] `docker compose pull && docker compose up -d` (no local Plume build)
+- [ ] `docker compose logs kithara` → AUTH-INVITE banner with Registration OTP (empty volume)
+- [ ] Claim → bind → create Struna → `/player/{slug}` + `/stream/{slug}`
+- [ ] Confirm `:5000` not reachable from public interface (org deploy — not local `compose.plume.yml`)
+- [ ] Confirm GHCR packages are **Public** (or pulls fail for anonymous operators) — one-time per package
+- [ ] Prefer one SemVer `IMAGE_TAG` for all four images (avoid mixed `:latest` SHAs)
+- [ ] Optional: set `OTEL_EXPORTER_OTLP_ENDPOINT` if verifying traces
+- [x] Optional (plume): CI asserts `wwwroot/dist` in the built image (prevent DEPLOY-PLUME-001 recurrence)
+- [x] Switch `local/deploy-test` Plume back to GHCR image when DEPLOY-PLUME-001 closed (follow-up)
+
+**Deferred (not publish blockers):** META-OPS-001 sine smoke, META-DOC-001 doc sweep, OTel continuous-play E2E, MESH-REG-* product pinning.
+
+---
+
+
+
+## Module-local notes
+
+
+| Module                                                                                                            | Note                                                                                  |
+| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| [Plume ideas](https://github.com/Bardie-radio/plume/blob/main/docs/architecture/ideas.md)                         | Vite dist must be in published image; local deploy-test builds from source until then |
+| [Magpie ideas](https://github.com/Bardie-radio/magpie/blob/main/docs/architecture/ideas.md)                       | Alpine 3.22 + libav pin; YouTube extract drift is runtime                             |
+| [Bes ideas](https://github.com/Bardie-radio/bes/blob/main/docs/architecture/ideas.md)                             | Alpine final; no public auth HTTP                                                     |
+| Org [05-deployment](https://github.com/Bardie-radio/.github/blob/main/profile/docs/architecture/05-deployment.md) | Operator narrative; link here for audit detail — do not duplicate Kithara internals   |
+
+
+---
+
+
+
+## Related
+
+- [security-audit.md](security-audit.md) — finding IDs + trust model  
+- [known-issues.md](known-issues.md) — NECK / META-OPS / META-OTEL  
+- [implementation-plan.md](implementation-plan.md) — Phase 8 ownership  
+- Org deploy: [profile/deploy](https://github.com/Bardie-radio/.github/tree/main/profile/deploy)
+
+**Read next:** [security-audit.md](security-audit.md) · publish checklist above

--- a/docs/architecture/mvp/security-audit.md
+++ b/docs/architecture/mvp/security-audit.md
@@ -2,9 +2,9 @@
 
 Living audit of trust assumptions across the Module mesh, auth vertical, library/storage, and guest paths. Not a full product pen-test — focused on **who can become trusted**, **who gets admin**, and **what tokens/keys actually do**.
 
-**Last review:** Full-stack MVP including Plume (Jul 2026). Prior: Phases 4–6 backend audit; Phases 1–3 index below.
+**Last review:** Pre-publish GHCR audit (26 Jul 2026) — see [pre-publish-audit.md](pre-publish-audit.md). Prior: full-stack MVP including Plume (Jul 2026); Phases 4–6 backend audit.
 
-**Remediation status:** Phase 4–6 product remediations remain **closed** / partial as in the status table. Plume Phases 1–6 **feature-complete** (`/player` autoplay is intentional). Soft residuals + Plume findings → Phase 8. `MESH-REG-*` stays ops + backlog.
+**Remediation status:** Phase 4–6 product remediations remain **closed** / partial as in the status table. Plume Phases 1–6 **feature-complete** (`/player` autoplay is intentional). Soft residuals + Plume findings → Phase 8. `MESH-REG-*` stays ops + backlog. **Publish gate:** Plume Vite `wwwroot/dist` must be on GHCR (**DEPLOY-PLUME-001**).
 
 
 ### ID scheme
@@ -58,7 +58,7 @@ Historical aliases (`SEC-*`, `NEW-*`, `DES-*`, `KI-*`, `QA-*`, `DOC-*`, `OPS-*`)
 | [AUTH-ROT-001](#auth-rot-001--must_rotate_credentials-is-advisory-forever) | **P0** | Bes | Seed sets rotate flag; Authenticate never enforces / no password-change | **6** → **8** | **Fixed** — `UpdateUserBinding` + `bind_form`; host control gate (AUTH-ROT-002) |
 | [AUTH-ROLE-001](#auth-role-001--every-successful-login-mints-rolesadmin) | **P0** | Bes / AuthZ | Every mint hardcodes `roles=[admin]` | **6** | **Fixed** |
 | [AUTH-JWKS-001](#auth-jwks-001--jwks-resolver-uses-sync-over-async) | **P1** | Auth JWT | `GetAwaiter().GetResult()` in signing-key resolver | **6** | **Fixed** |
-| [GUEST-XCHG-001](#guest-xchg-001--guest-exchange-unauthenticated--no-rate-limit) | **P1** | Guests | Open `POST …/guest/exchange`; short codes brute-forceable | **6** | **Partial** — 10/min rate limit; lockout → GUEST-XCHG-002 |
+| [GUEST-XCHG-001](#guest-xchg-001--guest-exchange-unauthenticated--no-rate-limit) | **P1** | Guests | Open `POST …/guest/exchange`; short codes brute-forceable | **6** | **Fixed** — 10/min rate limit + GUEST-XCHG-002 lockout |
 | [MESH-CHN-001](#mesh-chn-001--work-port-mtls-trusts-ca-only--not-hostslug-pinned) | **P1** | Module.Channel | Work-port accepts any mesh-CA client cert; host dials skip server pin | **4** | **Fixed** |
 | [MESH-REG-001](#mesh-reg-001--slug-takeover-via-join-secret-auto) | High* | Registry | Join secret + Register window → slug takeover (auto) | Ops + backlog | **Open** |
 | MESH-REG-002 | Residual | Registry | Auto private-key-on-wire | Ops (`preshared`) | **Open** |
@@ -93,10 +93,11 @@ Historical aliases (`SEC-*`, `NEW-*`, `DES-*`, `KI-*`, `QA-*`, `DOC-*`, `OPS-*`)
 | **AUTH-CLAIM-001** | P1 | Claim JWT `bardie_bind_only` unread; admin claim could `/register` + search; access survived bind | **Fixed** — allow-list bindings+`/me`; no roles on claim JWT; register rejects pending; claim access dies after `CompleteInvite` |
 | **NECK-JOB-001** | P2 | TrackStatus disconnect without terminal event can orphan Neck jobs | **Fixed** — reconnect + capped give-up finalize; enables [NECK-SWP-001](known-issues.md#neck-swp-001--orphan-writer-sweep-runs-on-every-play-including-new-strunas) Fixed |
 | **GUEST-XCHG-002** | P2 | Guest failure lockout (5 failures → 15 min) | **Fixed** (Phase 8) |
+| **GUEST-XCHG-004** | P3 | Guest-code compare ordinal (not constant-time) | **Fixed** — `ListenTokenComparer.FixedTimeEquals` in `GuestJwtService.ExchangeAsync` |
 | **STREAM-TOK-001** | P2 | Listen-token compare not constant-time | **Fixed** — `CryptographicOperations.FixedTimeEquals` |
 | **AUTH-JWKS-002** | P2 | JWKS snapshot cold window at boot | **Fixed** — Register awaits JWKS; fail-closed rejects Register |
 | **META-QA-001** | P1 | Host E2E + Bes/Magpie module tests | **Fixed** — host invite claim→bind + guest/rotate; Bes/Magpie unit tests ([kithara#22](https://github.com/Bardie-radio/kithara/issues/22), bes#6, magpie#2) |
-| **META-DOC-001** | P3 | Plan/module docs lag code (incl. `/player` autoplay wording) | Phase 8 ([kithara#23](https://github.com/Bardie-radio/kithara/issues/23), [plume#12](https://github.com/Bardie-radio/plume/issues/12), bes#7, magpie#3) |
+| **META-DOC-001** | P3 | Plan/module docs lag code (incl. `/player` autoplay wording) | **Deferred** ([kithara#23](https://github.com/Bardie-radio/kithara/issues/23), [plume#12](https://github.com/Bardie-radio/plume/issues/12), bes#7, magpie#3) |
 | **META-OPS-002** | P2 | Final images: Ubuntu aspnet + full apt `ffmpeg`; Alpine + bare-minimum libav | **Fixed** ([kithara#33](https://github.com/Bardie-radio/kithara/issues/33), [magpie#6](https://github.com/Bardie-radio/magpie/issues/6), [plume#13](https://github.com/Bardie-radio/plume/issues/13), [bes#10](https://github.com/Bardie-radio/bes/issues/10)) — [known-issues](known-issues.md#meta-ops-002--final-images-bloated-ubuntu--full-ffmpeg) |
 | **META-OTEL-001** | P1 | Local Compose omits `OTEL_EXPORTER_OTLP_ENDPOINT` | **Fixed** ([kithara#34](https://github.com/Bardie-radio/kithara/issues/34)) — [known-issues](known-issues.md#meta-otel-001--local-compose-omits-otel_exporter_otlp_endpoint) |
 | **META-OTEL-002** | P1 | `Task.Run` drops Activity (Magpie track + Neck encode) | **Fixed** ([kithara#36](https://github.com/Bardie-radio/kithara/issues/36)) — [known-issues](known-issues.md#meta-otel-002--taskrun-drops-activity-context-magpie--neck) |
@@ -111,6 +112,18 @@ Historical aliases (`SEC-*`, `NEW-*`, `DES-*`, `KI-*`, `QA-*`, `DOC-*`, `OPS-*`)
 | **PLUME-SEC-002** | P2 | BFF state-changing routes: SameSite only (no antiforgery tokens) | **Fixed** — `X-CSRF-TOKEN` / form antiforgery on unsafe `/bff/*` |
 | **PLUME-SESS-001** | P2 | In-memory session token store (multi-replica / restart) | **Deferred** — MVP single-replica (documented in Plume security-notes) |
 | **GUEST-XCHG-003** | P3 | Dual guest-exchange routes (id vs slug) → separate rate-limit partitions | **Open** |
+
+### Pre-publish audit (26 Jul 2026)
+
+| ID | Sev | Summary | Status |
+|----|-----|---------|--------|
+| **DEPLOY-PLUME-001** | Blocker | GHCR Plume image missing Vite `wwwroot/dist` (MIME/nosniff empty assets) | **Open** until republish — fix in plume Dockerfile/csproj; [pre-publish-audit](pre-publish-audit.md) |
+| **AUTH-FWD-001** | P2 | Guest/invite rate limits use `RemoteIpAddress` without `UseForwardedHeaders` → one partition for all clients behind nginx | **Fixed** — `UseForwardedHeaders` + operator knobs `BARDIE_FORWARDED_HEADERS_*` (default ForwardLimit 2) — needs image publish |
+| **PLUME-FWD-001** | P2 | Session `Secure = IsHttps` ignores `X-Forwarded-Proto` from edge | **Fixed** — Plume `UseForwardedHeaders` + bundled nginx preserves upstream proto — needs image publish |
+| **META-CFG-001** | P3 | Kithara image `appsettings.json` embeds demo `BARDIE_JOIN_SECRETS` (Compose env overrides); alias **MESH-JOIN-001** | **Fixed** — demo secrets Development-only; Production requires env/Compose |
+| **META-LOG-001** | P3 | EF SQL + framework noise; OTP welcome hard to spot | **Fixed** in source (quiet Production logging + AUTH-INVITE banner) — needs image publish |
+| **META-DEPLOY-001** | P2 | Local MVP compose (`compose.plume.yml` / phase2/3) publishes Kithara `:5000` with demo join secrets — not the reference-stack pattern | **Open** (dev-only; org `profile/deploy` keeps gRPC internal) |
+| **GUEST-XCHG-004** | P3 | Guest-code string compare not constant-time | **Fixed** this pass (see soft residuals) |
 
 **Withdrawn — not a product bug:** former **PLUME-AUD-001** (public `/player` auto-start). **Decision (Jul 2026):** the listen/player page is expected to play on load. Track as **docs only** under [META-DOC-001](https://github.com/Bardie-radio/kithara/issues/23) and [plume#12](https://github.com/Bardie-radio/plume/issues/12): replace “audio off by default” with “`/player` autoplays; optional listen elsewhere is opt-in.”
 
@@ -244,12 +257,11 @@ Resolver calls `GetAllSigningKeysAsync(...).GetAwaiter().GetResult()` — deadlo
 
 **Severity:** P1  
 **Component:** `POST …/guest/exchange`  
-**Fix:** Phase **6** (already listed as open)
+**Fix:** Phase **6** (rate limit) + Phase **8** (lockout GUEST-XCHG-002) — **Fixed**
 
 Endpoint is open; short guest codes are brute-forceable without rate limiting.
 
-**Remediation:** Per-IP / per-Struna rate limits + lockout after N failures (and optional CAPTCHA later — out of MVP).
-
+**Remediation (shipped):** Per-IP / per-Struna rate limits + lockout after N failures (GUEST-XCHG-002). Constant-time guest-code compare → GUEST-XCHG-004. Optional CAPTCHA later — out of MVP.
 ---
 
 ## MESH-CHN-001 — Work-port mTLS trusts CA only — not host↔slug pinned
@@ -356,7 +368,10 @@ Join secret is the **bootstrap** credential before mTLS exists. Auto deliberatel
 - [x] Plume BFF: no JWT in browser; discovery without provider-id branching; CSP + antiforgery (PLUME-SEC-001/002)
 - [x] Plume `/player` may autoplay (product intent — docs under META-DOC-001)
 - [x] Alpine finals + bare `ffmpeg-libav*` for Kithara/Magpie (META-OPS-002)
-- [ ] Phase 8: host E2E + module tests + remaining doc sweep
+- [x] Phase 8: reference Compose + nginx ([org deploy](https://github.com/Bardie-radio/.github/tree/main/profile/deploy)); host E2E + module tests (META-QA-001)
+- [ ] Remaining doc sweep (META-DOC-001 deferred) · META-OPS-001 deferred · OTel continuous-play E2E deferred
+- [x] Forwarded-headers for rate limits / cookies (AUTH-FWD-001 / PLUME-FWD-001) — source Fixed; publish with release
+- [ ] Publish Plume with Vite `wwwroot/dist` (DEPLOY-PLUME-001)
 
 ---
 
@@ -388,6 +403,7 @@ Join secret is the **bootstrap** credential before mTLS exists. Auto deliberatel
 
 ## Related
 
+- [pre-publish-audit](pre-publish-audit.md) — GHCR release gate (deploy / deps / logging)
 - [implementation-plan](implementation-plan.md) — Phase 4–6 closed; soft residuals → Phase 8
 - [known-issues](known-issues.md) — non-security footguns (`NECK-*` / product polish)
 - [grpc-module-registry](../interfaces/grpc-module-registry.md) — dial rules + auto vs preshared

--- a/docs/architecture/operations/configuration.md
+++ b/docs/architecture/operations/configuration.md
@@ -6,12 +6,15 @@ Env and Compose knobs for the **Kithara container** — database, collectors, mo
 
 | Variable | Description |
 |----------|-------------|
-| `DbProvider` | `sqlite` (throwaway local only) or `postgres` (Compose / real deploys) |
-| `DbConnectionString` | EF connection string |
-| `OTEL_EXPORTER_OTLP_ENDPOINT` | Optional. External collector URL (e.g. Alloy). Unset → no OTLP export. Local: opt-in overlays `compose.otel*.yml` — never defaulted in base sketches |
-| `BARDIE_JOIN_SECRETS` | Map of module slug → secret (source, auth, and client modules — register + static admin). Treat as root credentials for mesh bootstrap — [security-audit](../mvp/security-audit.md) |
+| `POSTGRES_HOST` | When set, use Postgres — Jellyfin-style discrete knobs. **Required in Production** (Compose / GHCR image) |
+| `POSTGRES_PORT` | Default `5432` |
+| `POSTGRES_DB` / `POSTGRES_USER` / `POSTGRES_PASSWORD` | Database name / role / password (`PASSWORD` required with `HOST`) |
+| `DbProvider` | `sqlite` (**Development only**) or `postgres` — Production rejects sqlite |
+| `DbConnectionString` | Full EF string for advanced overrides when `POSTGRES_HOST` is unset (Development sqlite, or Production `DbProvider=postgres`) |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Optional. External collector URL (e.g. Alloy). **Omit** when unused (SDK no-ops). Org deploy: uncomment in `profile/deploy/compose.yml` |
+| `BARDIE_JOIN_SECRETS` | Map of module slug → secret (source, auth, and client modules — register + static admin). **Required via env/Compose in Production** — not embedded in published `appsettings.json` (demo values only in Development). Treat as root credentials for mesh bootstrap — [security-audit](../mvp/security-audit.md) |
 | `BARDIE_MODULE_MTLS_BOOTSTRAP` | `auto` (default, private mesh) \| `preshared` (no private keys on Register) |
-| `BARDIE_GRPC_TLS_DATA_PATH` | Host CA + gRPC server cert directory (persist on a volume in real deploys) |
+| `BARDIE_GRPC_TLS_DATA_PATH` | Host CA + gRPC server cert directory. **Image default** `/data/mtls` — mount a volume on `/data` |
 | `BARDIE_MODULE_MTLS_PRESHARED_DIR` | Per-slug client cert dirs when bootstrap is `preshared` |
 | `BARDIE_AUTH_PROVIDER_PRIORITY` | Ordered provider slugs for claim/role arbitration |
 | `BARDIE_STRUNA_SILENCE_CLEANUP` | Auto-delete after silent duration (planned) |
@@ -19,14 +22,22 @@ Env and Compose knobs for the **Kithara container** — database, collectors, mo
 | `BARDIE_GUEST_JWT_ACCESS_TTL` | Access-token lifetime for ephemeral guests (default ~15m) |
 | `BARDIE_GUEST_JWT_REFRESH_*` | Refresh window for ephemeral guests (until Struna teardown / capped lifetime — sketch) |
 | `BARDIE_SEARCH_CACHE_TTL` | Timeout for durable/managed search-result cache (guests clear on Struna teardown) |
-| `BARDIE_STORAGE_DRIVER` | Blob backend: `local` (MVP default) \| `s3` \| later `webdav` |
-| `BARDIE_STORAGE_PATH` | Local driver root (volume or NFS/SMB mount) |
+| `BARDIE_STORAGE_DRIVER` | Blob backend: `local` (MVP) \| `s3` \| later `webdav`. **Required in Compose** (reference default `local`) |
+| `BARDIE_STORAGE_PATH` | Local driver root. **Required in Compose** when `local` (reference default `/data/blobs` on the Kithara `/data` volume). Image ENV may still default for bare `dotnet`/image runs |
 | `BARDIE_STORAGE_S3_*` | S3-compatible endpoint, bucket, region, credentials (sketch) |
-| `BARDIE_STRUNA_FIFO_PATH` | Shared volume root for **live Struna PCM FIFOs** (`{root}/strunas/{id}.pcm`). Not library downloads — those use `BARDIE_STORAGE_PATH` |
+| `BARDIE_STRUNA_FIFO_PATH` | Shared FIFO scratch root (`{root}/strunas/{id}.pcm`). **Image default** `/audio` — Kithara-only env. Magpie has **no** FIFO path knob; it opens the absolute `audio_endpoint` from StartTrack. Mount the **same** volume at that path on Magpie (and any other PCM writer) |
+| `BARDIE_FFMPEG_ROOT` | FFmpeg.AutoGen native lib directory. **Image default** `/usr/lib` (Alpine) |
+| `BARDIE_FORWARDED_HEADERS` | Optional master switch (`true`) — or set any of the knobs below. **Unset = no proxy** (do not honor `X-Forwarded-*`) |
+| `BARDIE_FORWARDED_HEADERS_FORWARD_LIMIT` | Proxy hops to trust. Reference Compose sets **2** (Traefik → nginx → app); single edge: `1`. No image/code default |
+| `BARDIE_FORWARDED_HEADERS_CLEAR_KNOWN` | When `true`, clear ASP.NET `KnownProxies` / `KnownIPNetworks` (Docker mesh). Reference Compose sets `true`. Unset/false keeps loopback-only trust |
+| `BARDIE_FORWARDED_HEADERS_KNOWN_PROXIES` | Optional comma-separated proxy IPs (applied after clear) |
+| `BARDIE_FORWARDED_HEADERS_KNOWN_NETWORKS` | Optional comma-separated CIDRs (e.g. `10.0.0.0/8`) |
 
 **User/login** JWT mint / refresh TTLs belong on the **auth module** (e.g. Bes) — Kithara only verifies those via module JWKS. Optional Kithara knobs later: JWKS cache / clock-skew tolerances.
 
-Library blobs (Magpie cache, Catbird uploads) use the storage driver above on **Kithara only** — modules do not duplicate `BARDIE_STORAGE_*`; they use Kithara as storage interface/discovery. See [storage](../domains/storage.md). Not Redis. Neck FIFOs use `BARDIE_STRUNA_FIFO_PATH` on Kithara **and** the same mount on source modules that write PCM.
+Library blobs (Magpie cache, Catbird uploads) use the storage driver above on **Kithara only** — modules do not duplicate `BARDIE_STORAGE_*`; they use Kithara as storage interface/discovery. See [storage](../domains/storage.md). Not Redis. Neck FIFOs: `BARDIE_STRUNA_FIFO_PATH` is **Kithara-only**; Magpie mounts the shared volume at the same path and writes wherever Kithara’s `audio_endpoint` points (Compose: one named volume → `/audio` on both).
+
+**Compose tip:** popular stacks (e.g. Jellyfin+Postgres) expose `POSTGRES_HOST` / `USER` / `PASSWORD` / `DB` instead of a monolithic connection string. Kithara follows that when `POSTGRES_HOST` is set; power users can still pass `DbConnectionString` with `POSTGRES_HOST` unset.
 
 ## Module discovery
 

--- a/src/Kithara/Features/Auth/GuestJwtService.cs
+++ b/src/Kithara/Features/Auth/GuestJwtService.cs
@@ -1,5 +1,6 @@
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
+using Kithara.Features.Streaming;
 using Kithara.Infrastructure.Persistence;
 using Kithara.Infrastructure.Persistence.Entities;
 using Microsoft.EntityFrameworkCore;
@@ -38,10 +39,11 @@ public sealed class GuestJwtService
         await using var db = await _dbFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
         var struna = await db.Strunas.FirstOrDefaultAsync(s => s.Id == strunaId, cancellationToken)
             .ConfigureAwait(false);
+        // GUEST-XCHG-004: same constant-time compare as listen tokens (STREAM-TOK-001).
         if (struna is null
             || struna.ControlAccess != ControlAccess.Protected
             || string.IsNullOrWhiteSpace(struna.GuestCode)
-            || !string.Equals(struna.GuestCode, guestCode.Trim(), StringComparison.Ordinal))
+            || !ListenTokenComparer.FixedTimeEquals(guestCode.Trim(), struna.GuestCode))
         {
             return null;
         }

--- a/src/Kithara/Features/Auth/InviteBootstrapHostedService.cs
+++ b/src/Kithara/Features/Auth/InviteBootstrapHostedService.cs
@@ -80,8 +80,23 @@ public sealed class InviteBootstrapHostedService : BackgroundService
 
     private void LogWelcome(InviteBootstrapResult result)
     {
+        // Banner stays Warning so it survives Production filters and stands out in compose logs.
+        // Intentional OTP plaintext — claim then bind_form; never log join secrets.
         _logger.LogWarning(
-            "BOOTSTRAP ADMIN (AUTH-INVITE): username={Username} id={UserId}. Registration OTP (log only — claim then bind_form): {Otp}",
+            """
+
+            ======================================================================
+              KITHARA AUTH-INVITE — BOOTSTRAP ADMIN
+            ----------------------------------------------------------------------
+              username:          {Username}
+              user id:           {UserId}
+              Registration OTP:  {Otp}
+            ----------------------------------------------------------------------
+              Next: open any user-aware client and claim user → enter username and
+                                 OTP → complete bind to any auth provider.
+              OTP is log-only (never on public HTTP). Rotate ops access if leaked.
+            ======================================================================
+            """,
             result.Username,
             result.UserId,
             result.RegistrationPassword);

--- a/src/Kithara/Infrastructure/Hosting/ForwardedHeadersConfiguration.cs
+++ b/src/Kithara/Infrastructure/Hosting/ForwardedHeadersConfiguration.cs
@@ -1,0 +1,143 @@
+using System.Net;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.HttpOverrides;
+
+namespace Kithara.Infrastructure.Hosting;
+
+/// <summary>
+/// Operator knobs for <see cref="ForwardedHeadersOptions"/> (AUTH-FWD-001).
+/// Unset = no proxy (do not honor <c>X-Forwarded-*</c>). Compose behind an edge must set knobs explicitly.
+/// </summary>
+public static class ForwardedHeadersConfiguration
+{
+    /// <summary>
+    /// True when any <c>BARDIE_FORWARDED_HEADERS*</c> / <c>ForwardedHeaders:*</c> knob is present.
+    /// </summary>
+    public static bool IsEnabled(IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        if (ParseBool(
+                FirstNonEmpty(
+                    configuration["BARDIE_FORWARDED_HEADERS"],
+                    configuration["ForwardedHeaders:Enabled"]),
+                defaultValue: false))
+        {
+            return true;
+        }
+
+        return FirstNonEmpty(
+            configuration["BARDIE_FORWARDED_HEADERS_FORWARD_LIMIT"],
+            configuration["ForwardedHeaders:ForwardLimit"],
+            configuration["BARDIE_FORWARDED_HEADERS_CLEAR_KNOWN"],
+            configuration["ForwardedHeaders:ClearKnown"],
+            configuration["BARDIE_FORWARDED_HEADERS_KNOWN_PROXIES"],
+            configuration["ForwardedHeaders:KnownProxies"],
+            configuration["BARDIE_FORWARDED_HEADERS_KNOWN_NETWORKS"],
+            configuration["ForwardedHeaders:KnownNetworks"]) is not null;
+    }
+
+    /// <summary>
+    /// Applies env / config overlays. When <see cref="IsEnabled"/> is false, disables forwarded headers
+    /// (direct clients / no edge). When enabled:
+    /// <list type="bullet">
+    /// <item><c>BARDIE_FORWARDED_HEADERS_FORWARD_LIMIT</c> — hops to trust (set in Compose; no code default)</item>
+    /// <item><c>BARDIE_FORWARDED_HEADERS_CLEAR_KNOWN</c> — clear KnownProxies/Networks when <c>true</c></item>
+    /// <item><c>BARDIE_FORWARDED_HEADERS_KNOWN_PROXIES</c> / <c>…_KNOWN_NETWORKS</c> — optional allowlists</item>
+    /// </list>
+    /// </summary>
+    public static void Apply(ForwardedHeadersOptions options, IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        if (!IsEnabled(configuration))
+        {
+            options.ForwardedHeaders = ForwardedHeaders.None;
+            return;
+        }
+
+        options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
+
+        var limitRaw = FirstNonEmpty(
+            configuration["BARDIE_FORWARDED_HEADERS_FORWARD_LIMIT"],
+            configuration["ForwardedHeaders:ForwardLimit"]);
+        if (int.TryParse(limitRaw, out var limit) && limit > 0)
+        {
+            options.ForwardLimit = limit;
+        }
+
+        if (ParseBool(
+                FirstNonEmpty(
+                    configuration["BARDIE_FORWARDED_HEADERS_CLEAR_KNOWN"],
+                    configuration["ForwardedHeaders:ClearKnown"]),
+                defaultValue: false))
+        {
+            options.KnownIPNetworks.Clear();
+            options.KnownProxies.Clear();
+        }
+
+        foreach (var proxy in SplitList(
+                     FirstNonEmpty(
+                         configuration["BARDIE_FORWARDED_HEADERS_KNOWN_PROXIES"],
+                         configuration["ForwardedHeaders:KnownProxies"])))
+        {
+            if (IPAddress.TryParse(proxy, out var address))
+            {
+                options.KnownProxies.Add(address);
+            }
+        }
+
+        foreach (var cidr in SplitList(
+                     FirstNonEmpty(
+                         configuration["BARDIE_FORWARDED_HEADERS_KNOWN_NETWORKS"],
+                         configuration["ForwardedHeaders:KnownNetworks"])))
+        {
+            if (System.Net.IPNetwork.TryParse(cidr, out var network))
+            {
+                options.KnownIPNetworks.Add(network);
+            }
+        }
+    }
+
+    private static bool ParseBool(string? raw, bool defaultValue)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return defaultValue;
+        }
+
+        return raw.Trim() switch
+        {
+            "1" or "true" or "True" or "TRUE" or "yes" or "YES" => true,
+            "0" or "false" or "False" or "FALSE" or "no" or "NO" => false,
+            _ => defaultValue,
+        };
+    }
+
+    private static IEnumerable<string> SplitList(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            yield break;
+        }
+
+        foreach (var part in raw.Split([',', ';', ' '], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            yield return part;
+        }
+    }
+
+    private static string? FirstNonEmpty(params string?[] values)
+    {
+        foreach (var value in values)
+        {
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                return value;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Kithara/Infrastructure/Neck/Neck.Queue.cs
+++ b/src/Kithara/Infrastructure/Neck/Neck.Queue.cs
@@ -80,6 +80,37 @@ public sealed partial class Neck
             },
             CancellationToken.None);
 
+        // Idle (no active track job): start the queue head so "add to queue" isn't stuck until Skip.
+        // Playing / paused keep a job — append only. Natural track-end clears the job and may leave
+        // a draining now-playing snapshot; enqueue should kick off the next head without a Skip.
+        if (!_jobs.ContainsKey(strunaId))
+        {
+            var gate = Gate(strunaId);
+            await gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                if (!_jobs.ContainsKey(strunaId))
+                {
+                    _encoder.SetSilence(strunaId, true);
+                    try
+                    {
+                        await AdvanceQueueHeadCoreAsync(strunaId, cancellationToken).ConfigureAwait(false);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning(
+                            ex,
+                            "Queue advance failed after idle enqueue on Struna {Id}",
+                            strunaId);
+                    }
+                }
+            }
+            finally
+            {
+                gate.Release();
+            }
+        }
+
         return (entry, null);
     }
 

--- a/src/Kithara/Infrastructure/Persistence/PersistenceServiceCollectionExtensions.cs
+++ b/src/Kithara/Infrastructure/Persistence/PersistenceServiceCollectionExtensions.cs
@@ -12,10 +12,7 @@ public static class PersistenceServiceCollectionExtensions
         this IServiceCollection services,
         IConfiguration configuration)
     {
-        var provider = (configuration["DbProvider"] ?? "sqlite").Trim().ToLowerInvariant();
-        var connectionString = configuration["DbConnectionString"]
-            ?? configuration.GetConnectionString("Kithara")
-            ?? "Data Source=kithara.db";
+        var (provider, connectionString) = ResolveDatabase(configuration);
 
         services.AddDbContextFactory<KitharaDbContext>(options =>
         {
@@ -33,6 +30,91 @@ public static class PersistenceServiceCollectionExtensions
 
         services.AddSingleton<IAuthPersistence, EfAuthPersistence>();
         return services;
+    }
+
+    /// <summary>
+    /// Resolves EF provider + connection string.
+    /// Prefer Jellyfin-style <c>POSTGRES_HOST</c> / <c>POSTGRES_USER</c> / … when set (Compose).
+    /// SQLite is allowed only outside Production (Development / tests).
+    /// Production requires Postgres via <c>POSTGRES_HOST</c> or <c>DbProvider=postgres</c> + connection string.
+    /// </summary>
+    public static (string Provider, string ConnectionString) ResolveDatabase(IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        var postgresHost = FirstNonEmpty(
+            configuration["POSTGRES_HOST"],
+            configuration["BARDIE_POSTGRES_HOST"]);
+
+        if (!string.IsNullOrWhiteSpace(postgresHost))
+        {
+            var user = FirstNonEmpty(
+                configuration["POSTGRES_USER"],
+                configuration["BARDIE_POSTGRES_USER"]) ?? "kithara";
+            var password = FirstNonEmpty(
+                configuration["POSTGRES_PASSWORD"],
+                configuration["BARDIE_POSTGRES_PASSWORD"]);
+            if (string.IsNullOrWhiteSpace(password))
+            {
+                throw new InvalidOperationException(
+                    "POSTGRES_PASSWORD is required when POSTGRES_HOST is set.");
+            }
+
+            var database = FirstNonEmpty(
+                configuration["POSTGRES_DB"],
+                configuration["BARDIE_POSTGRES_DB"]) ?? "kithara";
+            var port = FirstNonEmpty(
+                configuration["POSTGRES_PORT"],
+                configuration["BARDIE_POSTGRES_PORT"]) ?? "5432";
+
+            var connectionString =
+                $"Host={postgresHost.Trim()};Port={port.Trim()};Database={database.Trim()};Username={user.Trim()};Password={password}";
+            return ("postgres", connectionString);
+        }
+
+        var provider = (configuration["DbProvider"] ?? "sqlite").Trim().ToLowerInvariant();
+        var connectionStringFallback = configuration["DbConnectionString"]
+            ?? configuration.GetConnectionString("Kithara");
+
+        if (IsProduction(configuration))
+        {
+            if (provider is "postgres" or "postgresql")
+            {
+                if (string.IsNullOrWhiteSpace(connectionStringFallback))
+                {
+                    throw new InvalidOperationException(
+                        "Production postgres requires POSTGRES_HOST (+ PASSWORD) or DbConnectionString.");
+                }
+
+                return (provider, connectionStringFallback);
+            }
+
+            throw new InvalidOperationException(
+                "Production requires Postgres (POSTGRES_HOST + POSTGRES_PASSWORD). SQLite is Development-only.");
+        }
+
+        return (provider, connectionStringFallback ?? "Data Source=kithara.db");
+    }
+
+    private static bool IsProduction(IConfiguration configuration)
+    {
+        var env = FirstNonEmpty(
+            configuration["ASPNETCORE_ENVIRONMENT"],
+            configuration["DOTNET_ENVIRONMENT"]);
+        return string.Equals(env, "Production", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string? FirstNonEmpty(params string?[] values)
+    {
+        foreach (var value in values)
+        {
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                return value;
+            }
+        }
+
+        return null;
     }
 
     /// <summary>

--- a/src/Kithara/Program.cs
+++ b/src/Kithara/Program.cs
@@ -10,9 +10,11 @@ using Kithara.Features.Modules;
 using Kithara.Features.Search;
 using Kithara.Features.Streams;
 using Kithara.Features.Streaming;
+using Kithara.Infrastructure.Hosting;
 using Kithara.Infrastructure.Neck;
 using Kithara.Infrastructure.Observability;
 using Kithara.Infrastructure.Persistence;
+using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 
@@ -41,6 +43,14 @@ builder.Services.AddHostedService<InviteBootstrapHostedService>();
 builder.Services.AddSingleton<GuestExchangeLockout>();
 builder.Services.AddSingleton<InviteClaimLockout>();
 builder.Services.AddSingleton<ClaimInviteJwtService>();
+
+// AUTH-FWD-001: honor X-Forwarded-* only when BARDIE_FORWARDED_HEADERS_* is set (Compose edge).
+// Unset = no proxy (direct clients / local).
+if (ForwardedHeadersConfiguration.IsEnabled(builder.Configuration))
+{
+    builder.Services.Configure<ForwardedHeadersOptions>(options =>
+        ForwardedHeadersConfiguration.Apply(options, builder.Configuration));
+}
 
 // GUEST-XCHG-001: guest-code exchange is unauthenticated — bound by IP + Struna id.
 builder.Services.AddRateLimiter(options =>
@@ -93,6 +103,21 @@ _ = app.Services.GetRequiredService<GuestJwtSigningKeyStore>().GetSigningKey();
 
 await app.MigrateKitharaDatabaseAsync().ConfigureAwait(false);
 
+app.Logger.LogInformation(
+    """
+
+    ======================================================================
+      KITHARA ready
+    ----------------------------------------------------------------------
+      HTTP :8080  ·  module gRPC :5000 (internal)
+      Empty DB → AUTH-INVITE OTP appears below as a WARNING banner.
+    ======================================================================
+    """);
+
+if (ForwardedHeadersConfiguration.IsEnabled(app.Configuration))
+{
+    app.UseForwardedHeaders();
+}
 app.UseAuthentication();
 app.UseAuthorization();
 app.UseRateLimiter();

--- a/src/Kithara/appsettings.Development.json
+++ b/src/Kithara/appsettings.Development.json
@@ -2,7 +2,13 @@
   "Logging": {
     "LogLevel": {
       "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+      "Microsoft.AspNetCore": "Warning",
+      "Microsoft.EntityFrameworkCore.Database.Command": "Information",
+      "System.Net.Http.HttpClient": "Warning"
     }
-  }
+  },
+  "DetailedErrors": true,
+  "DbProvider": "sqlite",
+  "DbConnectionString": "Data Source=kithara.db",
+  "BARDIE_JOIN_SECRETS": "{\"dummy\":\"dummy-join-secret\",\"bes\":\"bes-join-secret\",\"magpie\":\"magpie-join-secret\"}"
 }

--- a/src/Kithara/appsettings.Production.json
+++ b/src/Kithara/appsettings.Production.json
@@ -1,0 +1,13 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.AspNetCore": "Warning",
+      "Microsoft.EntityFrameworkCore": "Warning",
+      "Microsoft.EntityFrameworkCore.Database.Command": "Warning",
+      "System": "Warning",
+      "System.Net.Http.HttpClient": "Warning"
+    }
+  }
+}

--- a/src/Kithara/appsettings.json
+++ b/src/Kithara/appsettings.json
@@ -2,12 +2,15 @@
   "Logging": {
     "LogLevel": {
       "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+      "Microsoft": "Warning",
+      "Microsoft.AspNetCore": "Warning",
+      "Microsoft.EntityFrameworkCore": "Warning",
+      "Microsoft.EntityFrameworkCore.Database.Command": "Warning",
+      "System": "Warning",
+      "System.Net.Http.HttpClient": "Warning"
     }
   },
   "AllowedHosts": "*",
-  "DbProvider": "sqlite",
-  "DbConnectionString": "Data Source=kithara.db",
   "ModuleChannel": {
     "UseMtls": true,
     "BootstrapMode": "Auto",
@@ -25,6 +28,5 @@
   "Neck": {
     "StrunaFifoRoot": "data/struna-fifos",
     "Mp3BitrateKbps": 128
-  },
-  "BARDIE_JOIN_SECRETS": "{\"dummy\":\"dummy-join-secret\",\"bes\":\"bes-join-secret\",\"magpie\":\"magpie-join-secret\"}"
+  }
 }

--- a/tests/Kithara.Tests/DatabaseConfigResolutionTests.cs
+++ b/tests/Kithara.Tests/DatabaseConfigResolutionTests.cs
@@ -1,0 +1,82 @@
+using Kithara.Infrastructure.Persistence;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace Kithara.Tests;
+
+public sealed class DatabaseConfigResolutionTests
+{
+    [Fact]
+    public void ResolveDatabase_uses_postgres_host_knobs_like_jellyfin()
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ASPNETCORE_ENVIRONMENT"] = "Production",
+                ["DbProvider"] = "sqlite",
+                ["DbConnectionString"] = "Data Source=ignored.db",
+                ["POSTGRES_HOST"] = "db",
+                ["POSTGRES_USER"] = "kithara",
+                ["POSTGRES_PASSWORD"] = "secret",
+                ["POSTGRES_DB"] = "kithara",
+                ["POSTGRES_PORT"] = "5432",
+            })
+            .Build();
+
+        var (provider, cs) = PersistenceServiceCollectionExtensions.ResolveDatabase(config);
+
+        Assert.Equal("postgres", provider);
+        Assert.Equal(
+            "Host=db;Port=5432;Database=kithara;Username=kithara;Password=secret",
+            cs);
+    }
+
+    [Fact]
+    public void ResolveDatabase_requires_password_when_host_set()
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["POSTGRES_HOST"] = "db",
+            })
+            .Build();
+
+        Assert.Throws<InvalidOperationException>(() =>
+            PersistenceServiceCollectionExtensions.ResolveDatabase(config));
+    }
+
+    [Fact]
+    public void ResolveDatabase_allows_sqlite_outside_production()
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ASPNETCORE_ENVIRONMENT"] = "Development",
+                ["DbProvider"] = "sqlite",
+                ["DbConnectionString"] = "Data Source=kithara.db",
+            })
+            .Build();
+
+        var (provider, cs) = PersistenceServiceCollectionExtensions.ResolveDatabase(config);
+
+        Assert.Equal("sqlite", provider);
+        Assert.Equal("Data Source=kithara.db", cs);
+    }
+
+    [Fact]
+    public void ResolveDatabase_rejects_sqlite_in_production()
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ASPNETCORE_ENVIRONMENT"] = "Production",
+                ["DbProvider"] = "sqlite",
+                ["DbConnectionString"] = "Data Source=/data/db/kithara.db",
+            })
+            .Build();
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            PersistenceServiceCollectionExtensions.ResolveDatabase(config));
+        Assert.Contains("Production requires Postgres", ex.Message, StringComparison.Ordinal);
+    }
+}

--- a/tests/Kithara.Tests/ForwardedHeadersConfigurationTests.cs
+++ b/tests/Kithara.Tests/ForwardedHeadersConfigurationTests.cs
@@ -1,0 +1,70 @@
+using Kithara.Infrastructure.Hosting;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.HttpOverrides;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace Kithara.Tests;
+
+public sealed class ForwardedHeadersConfigurationTests
+{
+    [Fact]
+    public void Unset_means_no_proxy()
+    {
+        var config = new ConfigurationBuilder().Build();
+        Assert.False(ForwardedHeadersConfiguration.IsEnabled(config));
+
+        var options = new ForwardedHeadersOptions();
+        options.KnownProxies.Add(System.Net.IPAddress.Loopback);
+        ForwardedHeadersConfiguration.Apply(options, config);
+
+        Assert.Equal(ForwardedHeaders.None, options.ForwardedHeaders);
+        Assert.Contains(System.Net.IPAddress.Loopback, options.KnownProxies);
+    }
+
+    [Fact]
+    public void Apply_honors_operator_knobs_from_compose()
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["BARDIE_FORWARDED_HEADERS_FORWARD_LIMIT"] = "2",
+                ["BARDIE_FORWARDED_HEADERS_CLEAR_KNOWN"] = "true",
+                ["BARDIE_FORWARDED_HEADERS_KNOWN_PROXIES"] = "10.0.0.2",
+                ["BARDIE_FORWARDED_HEADERS_KNOWN_NETWORKS"] = "10.0.0.0/8",
+            })
+            .Build();
+
+        Assert.True(ForwardedHeadersConfiguration.IsEnabled(config));
+
+        var options = new ForwardedHeadersOptions();
+        options.KnownProxies.Add(System.Net.IPAddress.Loopback);
+        ForwardedHeadersConfiguration.Apply(options, config);
+
+        Assert.Equal(ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto, options.ForwardedHeaders);
+        Assert.Equal(2, options.ForwardLimit);
+        Assert.DoesNotContain(System.Net.IPAddress.Loopback, options.KnownProxies);
+        Assert.Contains(options.KnownProxies, a => a.ToString() == "10.0.0.2");
+        Assert.Single(options.KnownIPNetworks);
+    }
+
+    [Fact]
+    public void Clear_known_false_keeps_loopback_trust()
+    {
+        var options = new ForwardedHeadersOptions();
+        options.KnownProxies.Add(System.Net.IPAddress.Loopback);
+
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["BARDIE_FORWARDED_HEADERS_FORWARD_LIMIT"] = "1",
+                ["BARDIE_FORWARDED_HEADERS_CLEAR_KNOWN"] = "false",
+            })
+            .Build();
+
+        ForwardedHeadersConfiguration.Apply(options, config);
+
+        Assert.Contains(System.Net.IPAddress.Loopback, options.KnownProxies);
+        Assert.Equal(1, options.ForwardLimit);
+    }
+}

--- a/tests/Kithara.Tests/Kithara.Tests.csproj
+++ b/tests/Kithara.Tests/Kithara.Tests.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />


### PR DESCRIPTION
## Summary
- Promote `dev` → `main`: production publish hardening (Postgres, forwarded headers, quiet logs, AUTH-INVITE banner).
- Queue auto-advance when nothing is playing.
- Version bump `0.1.0` → `0.1.1` for the version-check gate.
